### PR TITLE
Support for ChannelBroadcast messages and other small fixes.

### DIFF
--- a/aclogview/CM_Inventory.cs
+++ b/aclogview/CM_Inventory.cs
@@ -167,7 +167,7 @@ public class CM_Inventory : MessageProcessor {
             TreeNode rootNode = new TreeNode(this.GetType().Name);
             rootNode.Expand();
             rootNode.Nodes.Add("i_item = " + Utility.FormatGuid(i_item));
-            rootNode.Nodes.Add("i_equipMask = " + Utility.FormatGuid(i_equipMask));
+            rootNode.Nodes.Add("i_equipMask = " + (INVENTORY_LOC)i_equipMask);
             treeView.Nodes.Add(rootNode);
         }
     }
@@ -217,12 +217,12 @@ public class CM_Inventory : MessageProcessor {
 
     public class GetAndWieldItem : Message {
         public uint i_item;
-        public uint i_loc;
+        public uint i_equipMask;
 
         public static GetAndWieldItem read(BinaryReader binaryReader) {
             GetAndWieldItem newObj = new GetAndWieldItem();
             newObj.i_item = binaryReader.ReadUInt32();
-            newObj.i_loc = binaryReader.ReadUInt32();
+            newObj.i_equipMask = binaryReader.ReadUInt32();
             return newObj;
         }
 
@@ -230,7 +230,7 @@ public class CM_Inventory : MessageProcessor {
             TreeNode rootNode = new TreeNode(this.GetType().Name);
             rootNode.Expand();
             rootNode.Nodes.Add("i_item = " + Utility.FormatGuid(i_item));
-            rootNode.Nodes.Add("i_loc = " + i_loc);
+            rootNode.Nodes.Add("i_equipMask = " + (INVENTORY_LOC)i_equipMask);
             treeView.Nodes.Add(rootNode);
         }
     }

--- a/aclogview/CM_Physics.cs
+++ b/aclogview/CM_Physics.cs
@@ -1497,7 +1497,7 @@ public class CM_Physics : MessageProcessor {
             TreeNode rootNode = new TreeNode(this.GetType().Name);
             rootNode.Expand();
             rootNode.Nodes.Add("object_id = " + Utility.FormatGuid(this.object_id));
-            rootNode.Nodes.Add("sound = " + sound);
+            rootNode.Nodes.Add("sound = " + "(" + sound + ") " + (SoundType)sound);
             rootNode.Nodes.Add("volume = " + volume);
             treeView.Nodes.Add(rootNode);
         }

--- a/aclogview/Enums/Chat.cs
+++ b/aclogview/Enums/Chat.cs
@@ -46,3 +46,108 @@ public enum ChatTypeEnum {
     SocietyRadBlo_ChatTypeEnum,
     Olthoi_ChatTypeEnum
 }
+
+public enum GroupChatType
+{
+    /// <summary>
+    /// Unknown
+    /// </summary>
+    /// Included for completeness since it is listed in the client
+    Unknown = 0x00000000,
+
+    /// <summary>
+    /// @abuse - Abuse Channel
+    /// </summary>
+    TellAbuse = 0x00000001,
+
+    /// <summary>
+    /// @admin - Admin Channel (@ad)
+    /// </summary>
+    TellAdmin = 0x00000002,
+
+    /// <summary>
+    /// @audit - Audit Channel (@au)
+    /// This channel was used to echo copies of enforcement commands (such as: ban, gag, boot) to all other online admins
+    /// </summary>
+    TellAudit = 0x00000004,
+
+    /// <summary>
+    /// @av1 - Advocate Channel (@advocate) (@advocate1)
+    /// </summary>
+    TellAdvocate = 0x00000008,
+
+    /// <summary>
+    /// @av2 - Advocate2 Channel (@advocate2)
+    /// </summary>
+    TellAdvocate2 = 0x00000010,
+
+    /// <summary>
+    /// @av3 - Advocate3 Channel (@advocate3)
+    /// </summary>
+    TellAdvocate3 = 0x000000020,
+
+    /// <summary>
+    /// @sent - Sentinel Channel (@sentinel)
+    /// </summary>
+    TellSentinel = 0x000000200,
+
+    /// <summary>
+    /// @[command name tbd] - Help Channel
+    /// </summary>
+    TellHelp = 0x000000400,
+
+    /// <summary>
+    /// @f - Tell Fellowship
+    /// </summary>
+    TellFellowship = 0x00000800,
+
+    /// <summary>
+    /// @v - Tell Vassals
+    /// </summary>
+    TellVassals = 0x00001000,
+
+    /// <summary>
+    /// @p - Tell Patron
+    /// </summary>
+    TellPatron = 0x00002000,
+
+    /// <summary>
+    /// @m - Tell Monarch
+    /// </summary>
+    TellMonarch = 0x00004000,
+
+    /// <summary>
+    /// @c - Tell Co-Vassals
+    /// </summary>
+    TellCoVassals = 0x01000000,
+
+    /// <summary>
+    /// @allegiance broadcast - Tell All Allegiance Members
+    /// </summary>
+    AllegianceBroadcast = 0x02000000,
+
+    /// <summary>
+    /// Player is now the leader of this fellowship.
+    /// </summary>
+    FellowshipBroadcast = 0x04000000,
+
+    /// <summary>
+    /// Celestial Hand Society
+    /// </summary>
+    CelestialHandBroadcast = 0x08000000,
+
+    /// <summary>
+    /// Eldrytch Web Society
+    /// </summary>
+    EldrytchWebBroadcast = 0x10000000,
+
+    /// <summary>
+    /// Radiant Blood Society
+    /// </summary>
+    RadiantBloodBroadcast = 0x20000000,
+
+    /// <summary>
+    /// Olthoi
+    /// </summary>
+    OlthoiBroadcast = 0x40000000
+}

--- a/aclogview/Enums/StatTypes.cs
+++ b/aclogview/Enums/StatTypes.cs
@@ -1032,7 +1032,7 @@ public enum SMainCat
 {
     Cooldown_Category = 0x00,
     Life_Magic_Non_Natural_Armor_Category = 0x50,   // All Life spells except those which affect natural armor like Armor Self I etc.
-    All_Skills_Reduction_Category = 0x60,
+    All_Skills_And_Vitals_Reduction_Category = 0x60, // Vitae and other stat reduction spells
     Dirty_Fighting_Debuff_Category = 0x80,
     War_Item_Creature_Void_Magic_Category = 0x90,   // Seems to be a catch all
     Natural_Armor_Category = 0xa0


### PR DESCRIPTION
* Added support for ChannelBroadcast messages.
* Known bug - treenode max display length (259 characters) will truncate lengthy text.
  You can still right-click and copy the full text to the clipboard.

* Added GroupChatType enums from ACE and added a few that were found in the client.
* Changed an SMainCat enum to a more descriptive name.
* Added a couple of enum conversions for inventory and sounds.