### PR TITLE
Find opcode in files "as messages" fix.

### DIFF
--- a/aclogview/FindOpcodeInFilesForm.cs
+++ b/aclogview/FindOpcodeInFilesForm.cs
@@ -183,7 +183,7 @@ namespace aclogview
             int hits = 0;
             int exceptions = 0;
 
-            var records = PCapReader.LoadPcap(fileName, false, ref searchAborted);
+            var records = PCapReader.LoadPcap(fileName, true, ref searchAborted);
 
             foreach (var record in records)
             {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### 2017-11-25
+[Slushnas]
+* Changed **_Find Opcode In Files_** to process files in "as messages" mode which fixes some cases where messages being searched for would not be found.
+
 ### 2017-11-20
 [Slushnas]
 * Added multiple hex and enum conversions to multiple messages.


### PR DESCRIPTION
A fix for some cases where the messages you are searching for are not found by processing files in "as messages" mode.