### PR TITLE
Add @Teleloc and parsed data hierarchy support

### DIFF
--- a/aclogview/ACETeleloc.cs
+++ b/aclogview/ACETeleloc.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Windows.Forms;
+
+namespace aclogview
+{
+    class ACETeleloc
+    {
+        public static void CopyACETelelocToClipboard(PacketRecord record)
+        {
+            try
+            {
+                using (BinaryReader fragDataReader = new BinaryReader(new MemoryStream(record.data)))
+                {
+                    var messageCode = fragDataReader.ReadUInt32();
+                    if (messageCode == 0xF7B1) // Game Action
+                    {
+                        var sequence = fragDataReader.ReadUInt32(); // Sequence
+                        messageCode = fragDataReader.ReadUInt32(); // Event
+                    }
+                    string telelocLine;
+
+                    if (messageCode == (int)PacketOpcode.Evt_Physics__CreateObject_ID)
+                    {
+                        var parsed = CM_Physics.CreateObject.read(fragDataReader);
+                        if ((parsed.physicsdesc.bitfield & (uint)CM_Physics.PhysicsDesc.PhysicsDescInfo.POSITION) != 0)
+                            telelocLine = GetTelelocString(parsed.physicsdesc.pos);
+                        else
+                            throw new Exception("This message does not contain a position.");
+                    }
+                    else if (messageCode == (int)PacketOpcode.Evt_Movement__UpdatePosition_ID)
+                    {
+                        var parsed = CM_Movement.UpdatePosition.read(fragDataReader);
+                        telelocLine = GetTelelocString(parsed.positionPack.position);
+                    }
+                    else if (messageCode == (int)PacketOpcode.Evt_Movement__MoveToState_ID)
+                    {
+                        var parsed = CM_Movement.MoveToState.read(fragDataReader);
+                        telelocLine = GetTelelocString(parsed.position);
+                    }
+                    else
+                    {
+                        throw new Exception();
+                    }
+                    Clipboard.SetText(telelocLine);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Could not copy @teleloc line.\n{ex.Message}", "Error:", MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+        }
+
+        public static string GetTelelocString(Position position)
+        {
+            return $"@teleloc {position.objcell_id:X8} {position.frame.m_fOrigin.x} {position.frame.m_fOrigin.y} {position.frame.m_fOrigin.z} {position.frame.qw} {position.frame.qx} {position.frame.qy} {position.frame.qz}";
+        }
+
+        public static bool MessageContainsPosition(int Opcode)
+        {
+            switch (Opcode)
+            {
+                case (int)PacketOpcode.Evt_Physics__CreateObject_ID:
+                case (int)PacketOpcode.Evt_Movement__UpdatePosition_ID:
+                case (int)PacketOpcode.Evt_Movement__MoveToState_ID:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/aclogview/App.config
+++ b/aclogview/App.config
@@ -40,6 +40,9 @@
                 <setting name="PacketsListviewTimeFormat" serializeAs="String">
                         <value>0</value>
                 </setting>
+                <setting name="TreeviewCopyAllPadding" serializeAs="String">
+                        <value>3</value>
+                </setting>
         </aclogview.Properties.Settings>
     </userSettings>
 </configuration>

--- a/aclogview/Form1.Designer.cs
+++ b/aclogview/Form1.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace aclogview {
+namespace aclogview {
     partial class Form1 {
         /// <summary>
         /// Required designer variable.
@@ -53,12 +53,12 @@
             this.copyHexMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabProtocolDocs = new System.Windows.Forms.TabPage();
             this.protocolWebBrowser = new System.Windows.Forms.WebBrowser();
-            this.treeView_ParsedData = new BufferedTreeView();
             this.parsedContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.ExpandAll = new System.Windows.Forms.ToolStripMenuItem();
             this.CollapseAll = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.CopyAll = new System.Windows.Forms.ToolStripMenuItem();
+            this.TeleLoc = new System.Windows.Forms.ToolStripMenuItem();
             this.FindID = new System.Windows.Forms.ToolStripMenuItem();
             this.mainMenu = new System.Windows.Forms.MainMenu(this.components);
             this.menuItem_File = new System.Windows.Forms.MenuItem();
@@ -100,6 +100,7 @@
             this.checkBox_ShowObjects = new System.Windows.Forms.CheckBox();
             this.HighlightMode_comboBox = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
+            this.treeView_ParsedData = new BufferedTreeView();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer_Main)).BeginInit();
             this.splitContainer_Main.Panel1.SuspendLayout();
             this.splitContainer_Main.Panel2.SuspendLayout();
@@ -409,17 +410,6 @@
             this.protocolWebBrowser.Size = new System.Drawing.Size(1059, 380);
             this.protocolWebBrowser.TabIndex = 0;
             // 
-            // treeView_ParsedData
-            // 
-            this.treeView_ParsedData.ContextMenuStrip = this.parsedContextMenu;
-            this.treeView_ParsedData.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.treeView_ParsedData.Location = new System.Drawing.Point(0, 0);
-            this.treeView_ParsedData.Name = "treeView_ParsedData";
-            this.treeView_ParsedData.Size = new System.Drawing.Size(438, 410);
-            this.treeView_ParsedData.TabIndex = 0;
-            this.treeView_ParsedData.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treeView_ParsedData_AfterSelect);
-            this.treeView_ParsedData.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.treeView_ParsedData_NodeMouseClick);
-            // 
             // parsedContextMenu
             // 
             this.parsedContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -427,9 +417,10 @@
             this.CollapseAll,
             this.toolStripSeparator1,
             this.CopyAll,
+            this.TeleLoc,
             this.FindID});
             this.parsedContextMenu.Name = "parsedContextMenu";
-            this.parsedContextMenu.Size = new System.Drawing.Size(184, 98);
+            this.parsedContextMenu.Size = new System.Drawing.Size(184, 120);
             this.parsedContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.parsedContextMenu_Opening);
             this.parsedContextMenu.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.parsedContextMenu_ItemClicked);
             // 
@@ -456,6 +447,13 @@
             this.CopyAll.ShowShortcutKeys = false;
             this.CopyAll.Size = new System.Drawing.Size(183, 22);
             this.CopyAll.Text = "&Copy All";
+            // 
+            // TeleLoc
+            // 
+            this.TeleLoc.Name = "TeleLoc";
+            this.TeleLoc.Size = new System.Drawing.Size(183, 22);
+            this.TeleLoc.Text = "Copy ACE @teleloc";
+            this.TeleLoc.Visible = false;
             // 
             // FindID
             // 
@@ -794,6 +792,17 @@
             this.label1.TabIndex = 11;
             this.label1.Text = "Highlight Mode:";
             // 
+            // treeView_ParsedData
+            // 
+            this.treeView_ParsedData.ContextMenuStrip = this.parsedContextMenu;
+            this.treeView_ParsedData.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.treeView_ParsedData.Location = new System.Drawing.Point(0, 0);
+            this.treeView_ParsedData.Name = "treeView_ParsedData";
+            this.treeView_ParsedData.Size = new System.Drawing.Size(438, 410);
+            this.treeView_ParsedData.TabIndex = 0;
+            this.treeView_ParsedData.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treeView_ParsedData_AfterSelect);
+            this.treeView_ParsedData.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.treeView_ParsedData_NodeMouseClick);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -924,6 +933,7 @@
         private System.Windows.Forms.MenuItem menuItem_CheckUpdates;
         private System.Windows.Forms.MenuItem menuItem_Options;
         private System.Windows.Forms.MenuItem menuItem4;
+        private System.Windows.Forms.ToolStripMenuItem TeleLoc;
     }
 }
 

--- a/aclogview/Form1.cs
+++ b/aclogview/Form1.cs
@@ -1008,7 +1008,8 @@ namespace aclogview
                             strbuilder.Clear();
                             foreach (var node in GetTreeNodes(treeView_ParsedData.Nodes))
                             {
-                                strbuilder.AppendLine(node.Text);
+                                strbuilder.AppendLine($"{node.Text}".PadLeft(
+                                    node.Level * Settings.Default.TreeviewCopyAllPadding + node.Text.Length));
                             }
                             Clipboard.SetText(strbuilder.ToString());
                             break;

--- a/aclogview/Form1.cs
+++ b/aclogview/Form1.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -11,7 +11,6 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-
 using aclogview.Properties;
 using Be.Windows.Forms;
 
@@ -36,8 +35,9 @@ namespace aclogview
 
         private string pcapFilePath;
         private int currentOpcode;
-        private string currentDocOpcode;
-        private bool currentDocOpcodeIsC2S;
+        private int currentSelOpcode;
+        private int currentSelDocOpcode;
+        private bool currentSelOpcodeIsC2S;
         private uint currentUint;
         private string currentHighlightMode;
         private string currentCSText;
@@ -388,6 +388,8 @@ namespace aclogview
                 PacketRecord record = records[Int32.Parse(packetListItems[listView_Packets.SelectedIndices[0]].SubItems[0].Text)];
                 byte[] data = record.data;
 
+                if (record.opcodes.Count > 0) currentSelOpcode = (int)record.opcodes[0];
+
                 if (checkBox_useHighlighting.Checked && !loadedAsMessages)
                 {
                     hexBox1.SuspendLayout();
@@ -590,13 +592,12 @@ namespace aclogview
                 if (record.opcodes.Count == 0)
                 {
                     protocolWebBrowser.DocumentText = "";
-                    currentDocOpcode = null;
+                    currentSelOpcode = 0;
                     return;
                 }
-                var currentOpcodeString = "0x" + record.opcodes[0].ToString("X").Substring(4, 4);
                 bool isClientToServer = record.isSend;
                 if (tabControl1.SelectedTab == tabProtocolDocs)
-                    navigateToDocPage(currentOpcodeString, isClientToServer);
+                    navigateToDocPage((int)record.opcodes[0], isClientToServer);
             }
         }
 
@@ -1002,7 +1003,8 @@ namespace aclogview
                             treeView_ParsedData.EndUpdate();
                             break;
                         }
-                    case "CopyAll": {
+                    case "CopyAll":
+                        {
                             strbuilder.Clear();
                             foreach (var node in GetTreeNodes(treeView_ParsedData.Nodes))
                             {
@@ -1012,17 +1014,28 @@ namespace aclogview
                             break;
                         }
                     case "FindID":
-                        for (int i = 0; i < createdListItems.Count; i++)
                         {
-                            if (treeView_ParsedData.SelectedNode.Text.Contains(createdListItems[i].SubItems[1].Text))
+                            for (int i = 0; i < createdListItems.Count; i++)
                             {
-                                listView_CreatedObjects.Items[i].Selected = true;
-                                listView_CreatedObjects.TopItem = createdListItems[i];
-                                System.Media.SystemSounds.Asterisk.Play();
-                                break;
+                                if (treeView_ParsedData.SelectedNode.Text.Contains(createdListItems[i].SubItems[1].Text))
+                                {
+                                    listView_CreatedObjects.Items[i].Selected = true;
+                                    listView_CreatedObjects.TopItem = createdListItems[i];
+                                    System.Media.SystemSounds.Asterisk.Play();
+                                    break;
+                                }
                             }
+                            break;
                         }
-                        break;
+                    case "TeleLoc":
+                        {
+                            if (ACETeleloc.MessageContainsPosition(currentSelOpcode))
+                            {
+                                PacketRecord record = records[Int32.Parse(packetListItems[listView_Packets.SelectedIndices[0]].SubItems[0].Text)];
+                                ACETeleloc.CopyACETelelocToClipboard(record);
+                            }
+                            break;
+                        }
                 }
             }
         }
@@ -1532,13 +1545,11 @@ namespace aclogview
             e.Cancel = (treeView_ParsedData.Nodes.Count == 0);
             // Only display "Find ID in Object List" option if the list is open
             if (treeView_ParsedData.SelectedNode != null && createdListItems.Count > 0)
-            {
                 FindID.Visible = true;
-            }
             else
-            {
                 FindID.Visible = false;
-            }
+
+            TeleLoc.Visible = ACETeleloc.MessageContainsPosition(currentSelOpcode);
         }
 
         private void objectsContextMenu_Opening(object sender, CancelEventArgs e)
@@ -1576,11 +1587,12 @@ namespace aclogview
             }
         }
 
-        private void navigateToDocPage(string opcode, bool isClientToServer)
+        private void navigateToDocPage(int opcode, bool isClientToServer)
         {
-            if (opcode == currentDocOpcode && currentDocOpcodeIsC2S == isClientToServer) return;
-            currentDocOpcode = opcode;
-            currentDocOpcodeIsC2S = isClientToServer;
+            if (opcode == currentSelDocOpcode && currentSelOpcodeIsC2S == isClientToServer) return;
+            currentSelDocOpcode = opcode;
+            currentSelOpcodeIsC2S = isClientToServer;
+            var currentOpcodeString = "0x" + opcode.ToString("X8").Substring(4, 4);
             var direction = isClientToServer ? "C2S" : "S2C";
             protocolWebBrowser.DocumentText =
                 $"<!DOCTYPE HTML>" +
@@ -1590,7 +1602,7 @@ namespace aclogview
                 $"<link type = \"text/css\" rel = \"stylesheet\" href = \"file:///{projectDirectory}/Protocol Documentation/Classic.css\"/>" +
                 $"</head>" +
                 $"<frameset cols = \"*, *\" frameborder = \"yes\" framespacing = \"2\">" +
-                $"<frame name = \"frameMsg\" scrolling = \"yes\" src = \"file:///{projectDirectory}/Protocol Documentation/Messages/{opcode}-{direction}.html\"/>" +
+                $"<frame name = \"frameMsg\" scrolling = \"yes\" src = \"file:///{projectDirectory}/Protocol Documentation/Messages/{currentOpcodeString}-{direction}.html\"/>" +
                 "<frame name = \"frameType\" scrolling = \"yes\" src = \"" +
                 $"<head><link type='text/css' rel='stylesheet' href='file:///{projectDirectory}/Protocol Documentation/Classic.css'/></head>" +
                 "<body><p class='Prompt'>Click a type to display the definition in this window.</p></body>\"/>" +
@@ -1606,12 +1618,12 @@ namespace aclogview
             if (record.opcodes.Count > 0)
             {
                 var isClientToServer = record.isSend;
-                navigateToDocPage("0x" + record.opcodes[0].ToString("X").Substring(4, 4), isClientToServer);
+                navigateToDocPage((int)record.opcodes[0], isClientToServer);
             }
             else
             {
                 protocolWebBrowser.DocumentText = "";
-                currentDocOpcode = null;
+                currentSelOpcode = 0;
             }
         }
 

--- a/aclogview/Message Processors/CM_Physics.cs
+++ b/aclogview/Message Processors/CM_Physics.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -218,7 +218,7 @@ public class CM_Physics : MessageProcessor {
     }
 
     public class PhysicsDesc {
-        enum PhysicsDescInfo {
+        public enum PhysicsDescInfo {
             CSetup = (1 << 0),
             MTABLE = (1 << 1),
             VELOCITY = (1 << 2),

--- a/aclogview/Properties/Settings.Designer.cs
+++ b/aclogview/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace aclogview.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -139,6 +139,18 @@ namespace aclogview.Properties {
             }
             set {
                 this["PacketsListviewTimeFormat"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("3")]
+        public byte TreeviewCopyAllPadding {
+            get {
+                return ((byte)(this["TreeviewCopyAllPadding"]));
+            }
+            set {
+                this["TreeviewCopyAllPadding"] = value;
             }
         }
     }

--- a/aclogview/Properties/Settings.settings
+++ b/aclogview/Properties/Settings.settings
@@ -32,5 +32,8 @@
     <Setting Name="PacketsListviewTimeFormat" Type="System.Byte" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="TreeviewCopyAllPadding" Type="System.Byte" Scope="User">
+      <Value Profile="(Default)">3</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/aclogview/Tools/OptionsForm.Designer.cs
+++ b/aclogview/Tools/OptionsForm.Designer.cs
@@ -39,11 +39,16 @@
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.displayNodeTooltips = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.comboBox_TimeFormat = new System.Windows.Forms.ComboBox();
             this.label2 = new System.Windows.Forms.Label();
+            this.comboBox_TimeFormat = new System.Windows.Forms.ComboBox();
+            this.copyAllPadding = new System.Windows.Forms.TextBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
+            this.groupBox4.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox1
@@ -89,9 +94,9 @@
             // 
             // button_OK
             // 
-            this.button_OK.Location = new System.Drawing.Point(252, 214);
+            this.button_OK.Location = new System.Drawing.Point(252, 252);
             this.button_OK.Name = "button_OK";
-            this.button_OK.Size = new System.Drawing.Size(75, 23);
+            this.button_OK.Size = new System.Drawing.Size(75, 24);
             this.button_OK.TabIndex = 1;
             this.button_OK.Text = "OK";
             this.button_OK.UseVisualStyleBackColor = true;
@@ -100,9 +105,9 @@
             // button_Cancel
             // 
             this.button_Cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.button_Cancel.Location = new System.Drawing.Point(333, 214);
+            this.button_Cancel.Location = new System.Drawing.Point(333, 252);
             this.button_Cancel.Name = "button_Cancel";
-            this.button_Cancel.Size = new System.Drawing.Size(75, 23);
+            this.button_Cancel.Size = new System.Drawing.Size(75, 24);
             this.button_Cancel.TabIndex = 2;
             this.button_Cancel.Text = "Cancel";
             this.button_Cancel.UseVisualStyleBackColor = true;
@@ -110,10 +115,11 @@
             // 
             // groupBox2
             // 
+            this.groupBox2.Controls.Add(this.groupBox4);
             this.groupBox2.Controls.Add(this.displayNodeTooltips);
             this.groupBox2.Location = new System.Drawing.Point(12, 153);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(396, 54);
+            this.groupBox2.Size = new System.Drawing.Size(396, 89);
             this.groupBox2.TabIndex = 3;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Treeview";
@@ -121,7 +127,7 @@
             // displayNodeTooltips
             // 
             this.displayNodeTooltips.AutoSize = true;
-            this.displayNodeTooltips.Location = new System.Drawing.Point(6, 19);
+            this.displayNodeTooltips.Location = new System.Drawing.Point(6, 37);
             this.displayNodeTooltips.Name = "displayNodeTooltips";
             this.displayNodeTooltips.Size = new System.Drawing.Size(123, 17);
             this.displayNodeTooltips.TabIndex = 0;
@@ -139,6 +145,15 @@
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Packets ListView";
             // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(6, 23);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(137, 13);
+            this.label2.TabIndex = 1;
+            this.label2.Text = "Time column display format:";
+            // 
             // comboBox_TimeFormat
             // 
             this.comboBox_TimeFormat.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
@@ -152,14 +167,42 @@
             this.comboBox_TimeFormat.TabIndex = 0;
             this.comboBox_TimeFormat.SelectedIndexChanged += new System.EventHandler(this.comboBox_TimeFormat_SelectedIndexChanged);
             // 
-            // label2
+            // copyAllPadding
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(6, 23);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(137, 13);
-            this.label2.TabIndex = 1;
-            this.label2.Text = "Time column display format:";
+            this.copyAllPadding.Location = new System.Drawing.Point(65, 22);
+            this.copyAllPadding.Name = "copyAllPadding";
+            this.copyAllPadding.Size = new System.Drawing.Size(33, 20);
+            this.copyAllPadding.TabIndex = 1;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(11, 25);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(48, 13);
+            this.label3.TabIndex = 2;
+            this.label3.Text = "Pad with";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(104, 25);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(43, 13);
+            this.label4.TabIndex = 3;
+            this.label4.Text = "Spaces";
+            // 
+            // groupBox4
+            // 
+            this.groupBox4.Controls.Add(this.label3);
+            this.groupBox4.Controls.Add(this.label4);
+            this.groupBox4.Controls.Add(this.copyAllPadding);
+            this.groupBox4.Location = new System.Drawing.Point(208, 19);
+            this.groupBox4.Name = "groupBox4";
+            this.groupBox4.Size = new System.Drawing.Size(179, 52);
+            this.groupBox4.TabIndex = 4;
+            this.groupBox4.TabStop = false;
+            this.groupBox4.Text = "Pad \"Copy All\" output";
             // 
             // OptionsForm
             // 
@@ -167,7 +210,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.button_Cancel;
-            this.ClientSize = new System.Drawing.Size(419, 246);
+            this.ClientSize = new System.Drawing.Size(419, 291);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.button_Cancel);
@@ -185,6 +228,8 @@
             this.groupBox2.PerformLayout();
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
+            this.groupBox4.ResumeLayout(false);
+            this.groupBox4.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -203,5 +248,9 @@
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.ComboBox comboBox_TimeFormat;
+        private System.Windows.Forms.GroupBox groupBox4;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.TextBox copyAllPadding;
     }
 }

--- a/aclogview/Tools/OptionsForm.cs
+++ b/aclogview/Tools/OptionsForm.cs
@@ -1,4 +1,4 @@
-﻿using aclogview.Properties;
+using aclogview.Properties;
 using System;
 using System.Security.Policy;
 using System.Windows.Forms;
@@ -11,6 +11,7 @@ namespace aclogview
         private byte _protocolUpdateIntervalDays;
         private bool _parsedDataTreeviewDisplayTooltips;
         private byte _packetsListviewTimeFormat;
+        private byte _treeviewCopyAllPadding;
 
         public OptionsForm()
         {
@@ -20,12 +21,14 @@ namespace aclogview
         private void Options_Load(object sender, EventArgs e)
         {
             LoadDefaultSettings();
+            // Now update the form with our settings
             textBox_ProtocolDays.Text = _protocolUpdateIntervalDays.ToString();
             checkBox_ProtocolUpdates.Checked = _protocolCheckForUpdates;
             if (!_protocolCheckForUpdates)
                 textBox_ProtocolDays.Enabled = false;
             displayNodeTooltips.Checked = _parsedDataTreeviewDisplayTooltips;
             comboBox_TimeFormat.SelectedIndex = _packetsListviewTimeFormat;
+            copyAllPadding.Text = _treeviewCopyAllPadding.ToString();
         }
 
         private void LoadDefaultSettings()
@@ -35,6 +38,7 @@ namespace aclogview
             _protocolCheckForUpdates = Settings.Default.ProtocolCheckForUpdates;
             _parsedDataTreeviewDisplayTooltips = Settings.Default.ParsedDataTreeviewDisplayTooltips;
             _packetsListviewTimeFormat = Settings.Default.PacketsListviewTimeFormat;
+            _treeviewCopyAllPadding = Settings.Default.TreeviewCopyAllPadding;
         }
 
         private void button_OK_Click(object sender, EventArgs e)
@@ -49,7 +53,8 @@ namespace aclogview
         {
             var result = FillProtocolSettings();
             if (!result) return false;
-            FillTreeviewSettings();
+            result = FillTreeviewSettings();
+            if (!result) return false;
 
             return true;
         }
@@ -60,12 +65,30 @@ namespace aclogview
             Settings.Default.ProtocolCheckForUpdates = _protocolCheckForUpdates;
             Settings.Default.ParsedDataTreeviewDisplayTooltips = _parsedDataTreeviewDisplayTooltips;
             Settings.Default.PacketsListviewTimeFormat = _packetsListviewTimeFormat;
+            Settings.Default.TreeviewCopyAllPadding = _treeviewCopyAllPadding;
             Settings.Default.Save();
         }
 
-        private void FillTreeviewSettings()
+        private bool FillTreeviewSettings()
         {
             _parsedDataTreeviewDisplayTooltips = displayNodeTooltips.Checked;
+            var isValidInput = ValidateCopyAllPadding();
+            return isValidInput && ParseCopyAllPadding();
+        }
+
+        private bool ValidateCopyAllPadding()
+        {
+            if (!string.IsNullOrWhiteSpace(copyAllPadding.Text)) return true;
+            DisplayInvalidPaddingTooltip();
+            return false;
+        }
+
+        private bool ParseCopyAllPadding()
+        {
+            var result = byte.TryParse(copyAllPadding.Text, out _treeviewCopyAllPadding);
+            if (result) return true;
+            DisplayByteConversionError("Pad \"Copy All\" output field");
+            return false;
         }
 
         private bool FillProtocolSettings()
@@ -87,11 +110,11 @@ namespace aclogview
         {
             var result = byte.TryParse(textBox_ProtocolDays.Text, out _protocolUpdateIntervalDays);
             if (result) return true;
-            DisplayByteConversionError(textBox_ProtocolDays.Text);
+            DisplayByteConversionError("protocol documentation update interval");
             return false;
         }
 
-        private void DisplayInvalidDaysTooltip ()
+        private void DisplayInvalidDaysTooltip()
         {
             toolTip_ProtocolDoc.ToolTipTitle = "Invalid Input";
             toolTip_ProtocolDoc.Show("You must enter a valid number of days for the update interval.",
@@ -100,10 +123,18 @@ namespace aclogview
                 5000);
         }
 
-        private static void DisplayByteConversionError (string updateDays)
+        private void DisplayInvalidPaddingTooltip()
         {
-            MessageBox.Show("Could not convert the protocol documentation " +
-                        $"update interval string '{updateDays}' to a byte.",
+            toolTip_ProtocolDoc.ToolTipTitle = "Invalid Input";
+            toolTip_ProtocolDoc.Show("You must enter a valid number padding spaces.",
+                this,
+                copyAllPadding.Location,
+                5000);
+        }
+
+        private static void DisplayByteConversionError(string field)
+        {
+            MessageBox.Show($"The {field} must be a number between 0-255.",
                         "Error:",
                         MessageBoxButtons.OK,
                         MessageBoxIcon.Error);

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -55,6 +56,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ACETeleloc.cs" />
     <Compile Include="BufferedTreeView.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### 2018-08-25
+[Slushnas]
+* Added an option to pad the treeview *Copy All* output so it doesn't have a flat structure. The default is 3 spaces.
+* Added support for creating/copying ACE **@teleloc** lines from CreateObject, UpdatePosition, and MoveToState messages.
+
 ### 2018-03-19
 [Slushnas]
 * Added context info to CM_Qualities and added/improved parsing of property values.


### PR DESCRIPTION
1. This will allow you to copy @teleloc lines from CreateObject, UpdatePosition, and MoveToState messages.
2. The parsed message data copied to the clipboard now has a hierarchical structure that can be adjusted or turned off in the options menu. I set the default to 3 spaces of indentation/padding as that produced what I think is the best result.