### PR TITLE
Combat damage given scraper

### DIFF
--- a/aclogview/App.config
+++ b/aclogview/App.config
@@ -46,6 +46,9 @@
                 <setting name="ACEStyleHeaders" serializeAs="String">
                         <value>False</value>
                 </setting>
+                <setting name="CreatureNameCombat" serializeAs="String">
+                        <value />
+                </setting>
         </aclogview.Properties.Settings>
     </userSettings>
   <runtime>

--- a/aclogview/Form1.Designer.cs
+++ b/aclogview/Form1.Designer.cs
@@ -393,7 +393,7 @@ namespace aclogview {
             this.copyTextMenuItem,
             this.copyHexMenuItem});
             this.hexContextMenu.Name = "hexContextMenu";
-            this.hexContextMenu.Size = new System.Drawing.Size(214, 48);
+            this.hexContextMenu.Size = new System.Drawing.Size(215, 48);
             this.hexContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.hexContextMenu_Opening);
             this.hexContextMenu.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.hexContextMenu_ItemClicked);
             // 
@@ -401,7 +401,7 @@ namespace aclogview {
             // 
             this.copyTextMenuItem.Name = "copyTextMenuItem";
             this.copyTextMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyTextMenuItem.Size = new System.Drawing.Size(213, 22);
+            this.copyTextMenuItem.Size = new System.Drawing.Size(214, 22);
             this.copyTextMenuItem.Text = "Copy as &Text";
             // 
             // copyHexMenuItem
@@ -409,7 +409,7 @@ namespace aclogview {
             this.copyHexMenuItem.Name = "copyHexMenuItem";
             this.copyHexMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.C)));
-            this.copyHexMenuItem.Size = new System.Drawing.Size(213, 22);
+            this.copyHexMenuItem.Size = new System.Drawing.Size(214, 22);
             this.copyHexMenuItem.Text = "Copy as &Hex";
             // 
             // tabProtocolDocs

--- a/aclogview/Properties/Settings.Designer.cs
+++ b/aclogview/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace aclogview.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -163,6 +163,18 @@ namespace aclogview.Properties {
             }
             set {
                 this["ACEStyleHeaders"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CreatureNameCombat {
+            get {
+                return ((string)(this["CreatureNameCombat"]));
+            }
+            set {
+                this["CreatureNameCombat"] = value;
             }
         }
     }

--- a/aclogview/Properties/Settings.settings
+++ b/aclogview/Properties/Settings.settings
@@ -38,5 +38,8 @@
     <Setting Name="ACEStyleHeaders" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="CreatureNameCombat" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/aclogview/Tools/CreatureName.Designer.cs
+++ b/aclogview/Tools/CreatureName.Designer.cs
@@ -71,6 +71,7 @@ namespace aclogview.Tools
             this.btnCancel.TabIndex = 2;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
             // CreatureName
             // 

--- a/aclogview/Tools/CreatureName.Designer.cs
+++ b/aclogview/Tools/CreatureName.Designer.cs
@@ -1,0 +1,99 @@
+﻿
+namespace aclogview.Tools
+{
+    partial class CreatureName
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.btnOK = new System.Windows.Forms.Button();
+            this.tbCreatureName = new System.Windows.Forms.TextBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // btnOK
+            // 
+            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btnOK.Location = new System.Drawing.Point(26, 82);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(117, 23);
+            this.btnOK.TabIndex = 1;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // tbCreatureName
+            // 
+            this.tbCreatureName.Location = new System.Drawing.Point(26, 40);
+            this.tbCreatureName.Name = "tbCreatureName";
+            this.tbCreatureName.Size = new System.Drawing.Size(240, 20);
+            this.tbCreatureName.TabIndex = 0;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(23, 24);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(75, 13);
+            this.label1.TabIndex = 3;
+            this.label1.Text = "CreatureName";
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(149, 82);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(117, 23);
+            this.btnCancel.TabIndex = 2;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            // 
+            // CreatureName
+            // 
+            this.AcceptButton = this.btnOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(285, 134);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.tbCreatureName);
+            this.Controls.Add(this.btnOK);
+            this.Name = "CreatureName";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "CreatureName";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        private System.Windows.Forms.TextBox tbCreatureName;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button btnCancel;
+        internal System.Windows.Forms.Button btnOK;
+    }
+}

--- a/aclogview/Tools/CreatureName.cs
+++ b/aclogview/Tools/CreatureName.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace aclogview.Tools
+{
+    public partial class CreatureName : Form
+    {
+        public string creatureName { get; set; }
+        public CreatureName()
+        {
+            InitializeComponent();
+        }
+
+        private void btnOK_Click(object sender, EventArgs e)
+        {
+
+            if (tbCreatureName.Text =="")
+                MessageBox.Show("Creature Name is blank", "Warning!");
+            creatureName = tbCreatureName.Text;
+        }
+    }
+}

--- a/aclogview/Tools/CreatureName.cs
+++ b/aclogview/Tools/CreatureName.cs
@@ -37,5 +37,10 @@ namespace aclogview.Tools
             creatureName = tbCreatureName.Text;
             Settings.Default.CreatureNameCombat = tbCreatureName.Text;
         }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            
+        }
     }
 }

--- a/aclogview/Tools/CreatureName.cs
+++ b/aclogview/Tools/CreatureName.cs
@@ -1,3 +1,4 @@
+using aclogview.Properties;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -18,12 +19,23 @@ namespace aclogview.Tools
             InitializeComponent();
         }
 
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+
+            tbCreatureName.Text = Settings.Default.CreatureNameCombat;
+
+        }
+
+        // CreatureNameCombat
+
         private void btnOK_Click(object sender, EventArgs e)
         {
 
             if (tbCreatureName.Text =="")
                 MessageBox.Show("Creature Name is blank", "Warning!");
             creatureName = tbCreatureName.Text;
+            Settings.Default.CreatureNameCombat = tbCreatureName.Text;
         }
     }
 }

--- a/aclogview/Tools/CreatureName.resx
+++ b/aclogview/Tools/CreatureName.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/aclogview/Tools/PcapScraperForm.Designer.cs
+++ b/aclogview/Tools/PcapScraperForm.Designer.cs
@@ -49,6 +49,8 @@ namespace aclogview.Tools
             this.columnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.chkExcludeNonRetailPcaps = new System.Windows.Forms.CheckBox();
+            this.tbCreatureName = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
             this.statusStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.SuspendLayout();
@@ -83,14 +85,14 @@ namespace aclogview.Tools
             // 
             this.toolStripStatusLabel2.Margin = new System.Windows.Forms.Padding(20, 3, 0, 2);
             this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
-            this.toolStripStatusLabel2.Size = new System.Drawing.Size(60, 17);
+            this.toolStripStatusLabel2.Size = new System.Drawing.Size(59, 17);
             this.toolStripStatusLabel2.Text = "Total Hits:";
             // 
             // toolStripStatusLabel3
             // 
             this.toolStripStatusLabel3.Margin = new System.Windows.Forms.Padding(20, 3, 0, 2);
             this.toolStripStatusLabel3.Name = "toolStripStatusLabel3";
-            this.toolStripStatusLabel3.Size = new System.Drawing.Size(115, 17);
+            this.toolStripStatusLabel3.Size = new System.Drawing.Size(116, 17);
             this.toolStripStatusLabel3.Text = "Message Exceptions:";
             // 
             // btnChangeSearchPathRoot
@@ -108,7 +110,7 @@ namespace aclogview.Tools
             // 
             this.btnStopSearch.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnStopSearch.Enabled = false;
-            this.btnStopSearch.Location = new System.Drawing.Point(651, 81);
+            this.btnStopSearch.Location = new System.Drawing.Point(651, 105);
             this.btnStopSearch.Name = "btnStopSearch";
             this.btnStopSearch.Size = new System.Drawing.Size(121, 23);
             this.btnStopSearch.TabIndex = 12;
@@ -119,7 +121,7 @@ namespace aclogview.Tools
             // btnStartSearch
             // 
             this.btnStartSearch.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnStartSearch.Location = new System.Drawing.Point(524, 81);
+            this.btnStartSearch.Location = new System.Drawing.Point(524, 105);
             this.btnStartSearch.Name = "btnStartSearch";
             this.btnStartSearch.Size = new System.Drawing.Size(121, 23);
             this.btnStartSearch.TabIndex = 11;
@@ -160,15 +162,15 @@ namespace aclogview.Tools
             // 
             this.txtOutputFolder.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtOutputFolder.Location = new System.Drawing.Point(122, 55);
+            this.txtOutputFolder.Location = new System.Drawing.Point(92, 55);
             this.txtOutputFolder.Name = "txtOutputFolder";
-            this.txtOutputFolder.Size = new System.Drawing.Size(616, 20);
+            this.txtOutputFolder.Size = new System.Drawing.Size(646, 20);
             this.txtOutputFolder.TabIndex = 18;
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(24, 58);
+            this.label4.Location = new System.Drawing.Point(15, 58);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(71, 13);
             this.label4.TabIndex = 19;
@@ -182,7 +184,7 @@ namespace aclogview.Tools
             // chkMultiThread
             // 
             this.chkMultiThread.AutoSize = true;
-            this.chkMultiThread.Location = new System.Drawing.Point(384, 85);
+            this.chkMultiThread.Location = new System.Drawing.Point(386, 85);
             this.chkMultiThread.Name = "chkMultiThread";
             this.chkMultiThread.Size = new System.Drawing.Size(134, 17);
             this.chkMultiThread.TabIndex = 21;
@@ -201,10 +203,10 @@ namespace aclogview.Tools
             this.columnEnabled,
             this.columnName,
             this.columnDescription});
-            this.dataGridView1.Location = new System.Drawing.Point(12, 110);
+            this.dataGridView1.Location = new System.Drawing.Point(12, 135);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.RowHeadersVisible = false;
-            this.dataGridView1.Size = new System.Drawing.Size(760, 426);
+            this.dataGridView1.Size = new System.Drawing.Size(760, 402);
             this.dataGridView1.TabIndex = 22;
             // 
             // columnEnabled
@@ -232,18 +234,38 @@ namespace aclogview.Tools
             this.chkExcludeNonRetailPcaps.AutoSize = true;
             this.chkExcludeNonRetailPcaps.Checked = true;
             this.chkExcludeNonRetailPcaps.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(219, 85);
+            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(227, 85);
             this.chkExcludeNonRetailPcaps.Name = "chkExcludeNonRetailPcaps";
             this.chkExcludeNonRetailPcaps.Size = new System.Drawing.Size(150, 17);
             this.chkExcludeNonRetailPcaps.TabIndex = 23;
             this.chkExcludeNonRetailPcaps.Text = "Exclude Non-Retail Pcaps";
             this.chkExcludeNonRetailPcaps.UseVisualStyleBackColor = true;
             // 
+            // tbCreatureName
+            // 
+            this.tbCreatureName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tbCreatureName.Location = new System.Drawing.Point(225, 111);
+            this.tbCreatureName.Name = "tbCreatureName";
+            this.tbCreatureName.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName.TabIndex = 24;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(13, 115);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(197, 13);
+            this.label2.TabIndex = 25;
+            this.label2.Text = "Creature Name (only for CombatScraper)";
+            // 
             // PcapScraperForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(784, 561);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.tbCreatureName);
             this.Controls.Add(this.chkExcludeNonRetailPcaps);
             this.Controls.Add(this.dataGridView1);
             this.Controls.Add(this.chkMultiThread);
@@ -288,5 +310,7 @@ namespace aclogview.Tools
         private System.Windows.Forms.DataGridViewTextBoxColumn columnDescription;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel4;
         private System.Windows.Forms.CheckBox chkExcludeNonRetailPcaps;
+        private System.Windows.Forms.TextBox tbCreatureName;
+        private System.Windows.Forms.Label label2;
     }
 }

--- a/aclogview/Tools/PcapScraperForm.Designer.cs
+++ b/aclogview/Tools/PcapScraperForm.Designer.cs
@@ -49,8 +49,6 @@ namespace aclogview.Tools
             this.columnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.chkExcludeNonRetailPcaps = new System.Windows.Forms.CheckBox();
-            this.tbCreatureName = new System.Windows.Forms.TextBox();
-            this.label2 = new System.Windows.Forms.Label();
             this.statusStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.SuspendLayout();
@@ -184,7 +182,7 @@ namespace aclogview.Tools
             // chkMultiThread
             // 
             this.chkMultiThread.AutoSize = true;
-            this.chkMultiThread.Location = new System.Drawing.Point(386, 85);
+            this.chkMultiThread.Location = new System.Drawing.Point(248, 105);
             this.chkMultiThread.Name = "chkMultiThread";
             this.chkMultiThread.Size = new System.Drawing.Size(134, 17);
             this.chkMultiThread.TabIndex = 21;
@@ -234,38 +232,18 @@ namespace aclogview.Tools
             this.chkExcludeNonRetailPcaps.AutoSize = true;
             this.chkExcludeNonRetailPcaps.Checked = true;
             this.chkExcludeNonRetailPcaps.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(227, 85);
+            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(92, 105);
             this.chkExcludeNonRetailPcaps.Name = "chkExcludeNonRetailPcaps";
             this.chkExcludeNonRetailPcaps.Size = new System.Drawing.Size(150, 17);
             this.chkExcludeNonRetailPcaps.TabIndex = 23;
             this.chkExcludeNonRetailPcaps.Text = "Exclude Non-Retail Pcaps";
             this.chkExcludeNonRetailPcaps.UseVisualStyleBackColor = true;
             // 
-            // tbCreatureName
-            // 
-            this.tbCreatureName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tbCreatureName.Location = new System.Drawing.Point(225, 111);
-            this.tbCreatureName.Name = "tbCreatureName";
-            this.tbCreatureName.Size = new System.Drawing.Size(247, 20);
-            this.tbCreatureName.TabIndex = 24;
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(13, 115);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(197, 13);
-            this.label2.TabIndex = 25;
-            this.label2.Text = "Creature Name (only for CombatScraper)";
-            // 
             // PcapScraperForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(784, 561);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.tbCreatureName);
             this.Controls.Add(this.chkExcludeNonRetailPcaps);
             this.Controls.Add(this.dataGridView1);
             this.Controls.Add(this.chkMultiThread);
@@ -310,7 +288,5 @@ namespace aclogview.Tools
         private System.Windows.Forms.DataGridViewTextBoxColumn columnDescription;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel4;
         private System.Windows.Forms.CheckBox chkExcludeNonRetailPcaps;
-        private System.Windows.Forms.TextBox tbCreatureName;
-        private System.Windows.Forms.Label label2;
     }
 }

--- a/aclogview/Tools/PcapScraperForm.cs
+++ b/aclogview/Tools/PcapScraperForm.cs
@@ -86,8 +86,6 @@ namespace aclogview.Tools
         private bool writeOutputAborted;
         private bool searchCompleted;
 
-        public string formCreatureName = "";
-
         private void btnStartSearch_Click(object sender, EventArgs e)
         {
             try
@@ -109,7 +107,7 @@ namespace aclogview.Tools
                 searchAborted = false;
                 writeOutputAborted = false;
                 searchCompleted = false;
-                formCreatureName = tbCreatureName.Text;
+                
 
                 UpdateToolStrip("Processing Files");
 
@@ -212,12 +210,6 @@ namespace aclogview.Tools
                 if (searchAborted || Disposing || IsDisposed)
                     return;
 
-                if (scraper.ToString() == "CombatDamageGiven")
-                {
-                    if (formCreatureName == "")
-                        MessageBox.Show("Creature Name is blank", "Warning!", (MessageBoxButtons)MessageBoxIcon.Exclamation);
-                    break;
-                }
                 var results = scraper.ProcessFileRecords(fileName, records, ref searchAborted);
 
                 lock (resultsLockObject)

--- a/aclogview/Tools/PcapScraperForm.cs
+++ b/aclogview/Tools/PcapScraperForm.cs
@@ -86,6 +86,8 @@ namespace aclogview.Tools
         private bool writeOutputAborted;
         private bool searchCompleted;
 
+        public string formCreatureName = "";
+
         private void btnStartSearch_Click(object sender, EventArgs e)
         {
             try
@@ -107,6 +109,7 @@ namespace aclogview.Tools
                 searchAborted = false;
                 writeOutputAborted = false;
                 searchCompleted = false;
+                formCreatureName = tbCreatureName.Text;
 
                 UpdateToolStrip("Processing Files");
 
@@ -114,7 +117,6 @@ namespace aclogview.Tools
                 btnChangeSearchPathRoot.Enabled = false;
                 dataGridView1.Enabled = false;
                 btnStopSearch.Enabled = true;
-
                 timer1.Start();
 
                 ThreadPool.QueueUserWorkItem((state) =>
@@ -210,6 +212,12 @@ namespace aclogview.Tools
                 if (searchAborted || Disposing || IsDisposed)
                     return;
 
+                if (scraper.ToString() == "CombatDamageGiven")
+                {
+                    if (formCreatureName == "")
+                        MessageBox.Show("Creature Name is blank", "Warning!", (MessageBoxButtons)MessageBoxIcon.Exclamation);
+                    break;
+                }
                 var results = scraper.ProcessFileRecords(fileName, records, ref searchAborted);
 
                 lock (resultsLockObject)

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace aclogview.Tools.Scrapers
+{
+    class CombatDamageGiven :Scraper
+    {
+
+        public override string Description => "Exports Damage given to a creature by a player";
+
+        private uint damageDone = 0;
+        private uint damageType = 0;
+        private bool crititcalHit = false;
+        private string creatureName = "Rynthid Minion";
+
+        public override void Reset()
+        {
+            damageDone = 0;
+            damageType = 0;
+            crititcalHit = false;
+        }
+    
+
+        public override (int hits, int messageExceptions) ProcessFileRecords(string fileName, List<PacketRecord> records, ref bool searchAborted)
+        {
+            int hits = 0;
+            int messageExceptions = 0;
+            
+
+            foreach (PacketRecord record in records)
+            {
+                if (searchAborted)
+                    return (hits, messageExceptions);
+
+                try
+                {
+                    if (record.data.Length <= 4)
+                        continue;
+
+                    if (record.isSend)
+                        continue;
+
+                    using (var memoryStream = new MemoryStream(record.data))
+                    using (var binaryReader = new BinaryReader(memoryStream))
+                    {
+                        var messageCode = binaryReader.ReadUInt32();
+
+                        // if (messageCode == (uint)PacketOpcode.ATTACKER_NOTIFICATION_EVENT) // 0x01B1
+                        if (messageCode == (uint)PacketOpcode.WEENIE_ORDERED_EVENT) // 0x01B1
+                        {
+                            // var message = CM_Login.Login__CharacterSet.read(binaryReader);
+                            // var message = CM_Combat.AttackerNotificationEvent.read(binaryReader);
+                            var message = CM_Combat.AttackerNotificationEvent.read(binaryReader);
+
+                            lock (this)
+                            {
+                                if (message.defenders_name.ToString() == creatureName)
+                                {
+                                    hits++;
+                                    damageDone = message.damage;
+                                    damageType = message.damage_type;
+                                    if (message.critical == 1)
+                                        crititcalHit = true;
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (InvalidDataException)
+                {
+                    // This is a pcap parse error
+                }
+                catch (Exception ex)
+                {
+                    messageExceptions++;
+                    // Do something with the exception maybe
+                }
+            }
+
+            return (hits, messageExceptions);
+        }
+
+        public override void WriteOutput(string destinationRoot, ref bool writeOutputAborted)
+        {
+            var sb = new StringBuilder();
+            string header = $"Combat Damage for {creatureName} \r\n" +
+                            $"Damage,DamageType,Critical\r\n";
+            string combatInfo = $"{damageDone},{damageType},{crititcalHit}";
+
+            var fileName = GetFileName(destinationRoot, ".csv");
+            File.WriteAllText(fileName, header + combatInfo);
+        }
+
+    }
+}

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -18,12 +18,13 @@ namespace aclogview.Tools.Scrapers
         private bool crititcalHit = false;
         private string creatureName = "";
         private string combatInfo = "";
-
+        private bool haveCreatureName = false;
         public override void Reset()
         {
             damageDone = 0;
             damageType = "";
             crititcalHit = false;
+            //haveCreatureName = false;
         }
     
         public override (int hits, int messageExceptions) ProcessFileRecords(string fileName, List<PacketRecord> records, ref bool searchAborted)
@@ -31,18 +32,23 @@ namespace aclogview.Tools.Scrapers
             int hits = 0;
             int messageExceptions = 0;
 
-            using (CreatureName form = new CreatureName())
+            if (haveCreatureName == false)
             {
-                DialogResult dr = form.ShowDialog();
-                if (dr == DialogResult.OK)
+                using (CreatureName form = new CreatureName())
                 {
-                    creatureName = form.creatureName;
-                    if (creatureName == "")
-                        return (hits, messageExceptions);
-                }
-                else
-                {
-                    return (hits, messageExceptions);
+                    DialogResult dr = form.ShowDialog();
+                    if (dr == DialogResult.OK)
+                    {
+                        creatureName = form.creatureName;
+                        haveCreatureName = true;
+                        if (creatureName == "")
+                            return (hits, messageExceptions);
+                    }
+                    else
+                    {
+                        searchAborted = true;
+                        //return (hits, messageExceptions);
+                    }
                 }
             }
 
@@ -118,6 +124,8 @@ namespace aclogview.Tools.Scrapers
             var fileName = GetFileNameCombat(destinationRoot, creatureName, ".csv");
             if (creatureName != "")
                 File.WriteAllText(fileName, header + combatInfo);
+
+            haveCreatureName = false;
         }
 
         private string DamageType (uint dtype)

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Enums\StatTypes.cs" />
     <Compile Include="Tools\Parsers\OpcodeFinder.cs" />
     <Compile Include="Tools\Scrapers\AccountExporter.cs" />
+    <Compile Include="Tools\Scrapers\CombatDamageGiven.cs" />
     <Compile Include="Tools\Scrapers\HeatMapGenerator.cs" />
     <Compile Include="Tools\Scrapers\PacketSizeScraperC2S.cs" />
     <Compile Include="Tools\Parsers\SampleParser.cs" />

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -90,6 +90,12 @@
     </Compile>
     <Compile Include="Server.cs" />
     <Compile Include="ServerList.cs" />
+    <Compile Include="Tools\CreatureName.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Tools\CreatureName.Designer.cs">
+      <DependentUpon>CreatureName.cs</DependentUpon>
+    </Compile>
     <Compile Include="Tools\OptionsForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -222,6 +228,9 @@
     <Compile Include="Utility.cs" />
     <EmbeddedResource Include="GotoLine.resx">
       <DependentUpon>GotoLine.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Tools\CreatureName.resx">
+      <DependentUpon>CreatureName.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Tools\OptionsForm.resx">
       <DependentUpon>OptionsForm.cs</DependentUpon>


### PR DESCRIPTION
New Scrapper for finding Melee/Missile Damage in PCAPs.  You can find it in the list under PCAP scrapper menu.  Outputs to a csv file.  File name will have the name of the creature.  File only contains 3 values.  The damage given, damage type, and if damage given was a critical hit.  