### PR TITLE
Combat scrapper UI

### DIFF
--- a/aclogview/App.config
+++ b/aclogview/App.config
@@ -46,7 +46,19 @@
                 <setting name="ACEStyleHeaders" serializeAs="String">
                         <value>False</value>
                 </setting>
-                <setting name="CreatureNameCombat" serializeAs="String">
+                <setting name="CreatureNameCombat1" serializeAs="String">
+                        <value />
+                </setting>
+                <setting name="CreatureNameCombat2" serializeAs="String">
+                        <value />
+                </setting>
+                <setting name="CreatureNameCombat3" serializeAs="String">
+                        <value />
+                </setting>
+                <setting name="CreatureNameCombat4" serializeAs="String">
+                        <value />
+                </setting>
+                <setting name="CreatureNameCombat5" serializeAs="String">
                         <value />
                 </setting>
         </aclogview.Properties.Settings>

--- a/aclogview/App.config
+++ b/aclogview/App.config
@@ -46,6 +46,9 @@
                 <setting name="ACEStyleHeaders" serializeAs="String">
                         <value>False</value>
                 </setting>
+                <setting name="CreatureNameCombat" serializeAs="String">
+                        <value />
+                </setting>
         </aclogview.Properties.Settings>
     </userSettings>
   <runtime>

--- a/aclogview/CharacterList.txt
+++ b/aclogview/CharacterList.txt
@@ -1,0 +1,2933 @@
+1342178494,Azrakin
+1342179198,Cyberkiller
+1342181083,Baal
+1342181790,Fenn
+1342181842,Haji
+1342183662,Eichschet
+1342183844,The Anarchs
+1342188059,Kodiak
+1342191277,Mjollnir
+1342191312,Ice Eyes
+1342191318,Chief Wifebeater
+1342202025,Lai-Lynn
+1342202659,Crash
+1342212533,Jack Handyman
+1342212536,Bow Duke
+1342217300,Kirk of Rithwic
+1342218320,Dural
+1342219201,Dr Doom
+1342220523,Turok
+1342223697,Dwynna
+1342224097,Willoughby Spit
+1342233731,Kurse
+1342236569,Goblin
+1342239538,Fizbee
+1342241043,Maid of the Blade
+1342241366,Li'l Prob
+1342243275,Vasquaz the Archer
+1342244425,Ashahel
+1342245630,Dave was here
+1342246485,Pack man
+1342249174,Reign of the Crow
+1342251187,Killerwolf
+1342254282,Lt Ripley
+1342254297,Ripley the Mage
+1342256546,Hex
+1342257025,Disease
+1342259520,Heero-Yuy
+1342263323,Ssttaassttaa
+1342264661,Spectre
+1342269877,Jesse the Knight
+1342270612,Beast
+1342271037,Stabby Stabberstein
+1342271044,Pack Ma'am
+1342279213,Nozokai
+1342283587,Rajja
+1342295192,Nozo Kai
+1342299258,Hy's Stuff Holder
+1342300036,Devil's Blade
+1342305246,Mana Man II
+1342306713,Strider Longshanks
+1342309424,Faramyr
+1342320305,Doctor Evil
+1342321228,Elzy
+1342331244,Aikido
+1342335084,Branor
+1342335085,Faramyr
+1342335768,Prism
+1342336414,Temppy
+1342336547,Testinga
+1342337386,Ghar
+1342340464,Kildor
+1342340997,Jarrod Li
+1342347497,Cyndra
+1342353070,Evincar
+1342353787,Glorix
+1342360844,Stormcloud
+1342366526,Dez'Mron Treasurer
+1342368999,Scuba Steve
+1342371327,Ninwa Chang
+1342372383,Cowhead
+1342377334,Ogg Cave-Man
+1342378857,Cricket
+1342380067,Dural Wadesun
+1342382130,Cowhead's other mule
+1342383108,Hop Singh
+1342383542,Shakalakka
+1342391394,Mag-tinker
+1342391395,Mag-one
+1342391396,Mag-two
+1342391397,Mag-three
+1342391398,Mag-four
+1342391399,Mag-five
+1342391400,Mag-six
+1342391402,Mag-eight
+1342391403,Mag-nine
+1342391404,Mag-seven
+1342391462,Mag-z newb armor
+1342391503,Mag-z brass
+1342391504,Mag-z brass b
+1342391506,Mag-z steel
+1342391507,Mag-z steel b
+1342391508,Mag-z ivory
+1342391510,Mag-z imbue
+1342391511,Mag-z money
+1342391512,Mag-z temp
+1342391535,Mag-z granite
+1342391560,Mag-z steel c
+1342391561,Mag-z green garnet
+1342391631,Mag-z granite b
+1342391632,Mag-z imbue b
+1342391706,Mag-z temp b
+1342391707,Mag-z imbue gc
+1342391749,Mag-z green garnet b
+1342391772,Mag-z iron
+1342391773,Mag-z temp c
+1342391946,Mag-z iron b
+1342391955,Mag-z cov salvage
+1342392016,Mag-z newb weapons
+1342392081,Mag-z colo rings
+1342392153,Mag-z foolproof
+1342392432,Mag-z set adept
+1342392433,Mag-z set wise
+1342392434,Mag-z set hearty
+1342392435,Mag-z set defender
+1342392436,Mag-z epic armor
+1342392470,Mag-z twohands
+1342392472,Mag-z bows
+1342392508,Mag-z wands
+1342392509,Mag-z colo items
+1342392932,Mag-z trinkets
+1342392934,Mag-z bling b
+1342392935,Mag-z bling
+1342392936,Mag-z underwear b
+1342392937,Mag-z underwear
+1342393030,Mag-z leather
+1342393074,Mag-z colo rings b
+1342393075,Mag-z foolproof b
+1342393360,Mag-z old wands
+1342393763,Mag-z colo items b
+1342394545,Mag-z aetheria b
+1342394546,Mag-z aetheria r
+1342394547,Mag-z aetheria y
+1342394548,Mag-z cloaks
+1342394549,Mag-z imbue bling
+1342394550,Mag-z quest equip
+1342394789,Mag-z heavy
+1342394790,Mag-z light
+1342394791,Mag-z finesse
+1342395395,Mag-z rares
+1342395920,Mag-z heavy dagger
+1342395921,Mag-z heavy axe
+1342396876,Mag-z trinkets b
+1342397598,Mag-z spell comps
+1342398676,Mag-z tinker equip
+1342399728,Mag-z master
+1342401215,Callaway
+1342401215,Keoki Al-Maya
+1342401317,Mag-z dual legendaries
+1342403957,Mag-z rings
+1342404309,Mag-z money b
+1342405117,Mag-z bling c
+1342405118,Mag-z underwear c
+1342407446,Kira Sahoto
+1342409493,Xxxxx
+1342410155,Mooolie
+1342410232,Moolie
+1342410235,Moolfasa
+1342410388,Killerwolf
+1342410443,Chesty
+1342410606,Brambles
+1342410611,Snarg
+1342410652,Pom Pom
+1342410712,Grael
+1342410726,Moom
+1342410852,Hip
+1342410903,Holden Grease
+1342410990,Moving Company
+1342411002,Biggle
+1342411004,Triumph
+1342411167,Compy
+1342411187,Bridge Hermit
+1342411252,Snoo Snoo
+1342411621,Bromeliad
+1342411636,Rhonda
+1342411916,Cycad
+1342411962,Borage
+1342412026,Heliotrope
+1342412155,Tumnus
+1342412442,Miss Rumphius
+1342412628,Aquilegia
+1342412763,Take It
+1342412896,Pansy
+1342412897,Petaluma
+1342414600,Hell's Care Taker
+1342415063,Hakim al-Wanganator
+1342415682,Soul Stealer
+1342417572,Dwynna Wildshot
+1342423309,Keoki's Alchemist
+1342423741,Stargren Dragoon
+1342424857,Ogg's Main Mule Man
+1342425734,Manala al-Cabul
+1342426987,Aziz al-Jamal
+1342432869,Ashahell
+1342433482,Mag-z temp d
+1342434441,Mag-z cloaks b
+1342435121,Jynnx
+1342435553,Mag-z set dex
+1342435554,Mag-z set wise b
+1342435555,Mag-z set adept b
+1342435556,Mag-z set defender b
+1342435558,Mag-z bows b
+1342435852,Mag-z set hearty b
+1342435853,Mag-z pets
+1342436303,Sun-Lynn
+1342436702,I Help Cowhead
+1342436792,Exopaladin
+1342436799,Asdfasdfasdfasd
+1342436801,Lisa Grace Cole
+1342436802,Carrie Lynn VanDerven
+1342436803,Llllllllllllllllllll
+1342436806,Adsfasdfasdf
+1342436807,Asdfasdffafas
+1342436808,Afafafafafaf
+1342436809,Aassfafafasd
+1342436810,Asdfasdfasdfaa
+1342436812,Chelsea Case
+1342436813,Cristina Herrera
+1342436814,Karen Hjorten
+1342436815,Jody Smith
+1342436816,Isabel Umana
+1342436817,Kara Finch
+1342436818,Aaaabbbaaaba
+1342441436,Vivi-Orunitia
+1342442959,Slim the shaddy
+1342444898,Heero-Yuy
+1342446206,Red Fox
+1342446708,Kryptic
+1342447549,Soulless
+1342450668,Nostromo
+1342453501,Ssgonts
+1342453869,Branith
+1342460458,Heero-Yuys Mule
+1342461129,Yo ho ho
+1342463381,Bouji-Bouji
+1342465241,Lisa G
+1342469935,Inferno Of Death
+1342471512,Eichy
+1342478451,Gohe the Swift
+1342479658,Minaris
+1342480205,Oykib
+1342489183,Doris
+1342489648,Striderlongshanks
+1342501904,Evincar's Mule
+1342503241,Lil One
+1342506535,Big Black Mofo
+1342507060,Lauralise
+1342510072,Logan Darkstar
+1342512050,Eternal Spirit
+1342514224,Gryphon
+1342514441,Fluffy Bunny
+1342515946,Herrin
+1342515957,Jini Starburst
+1342517980,Egbert
+1342518978,Contra
+1342519067,Gryp
+1342520737,Lauralise
+1342522845,Halvard the Red
+1342524532,Red Rose
+1342525162,Sushi Maru
+1342526335,Mithril
+1342528504,Zoishe
+1342530658,Frostwind III
+1342531172,Ampeg
+1342531669,Faramyr
+1342534114,Death Tard
+1342536154,Archimedies
+1342538117,Prey
+1342539271,Tenzo Yoshihara
+1342539979,Kricket
+1342540280,Flayh Mule
+1342540334,Admon Faye
+1342540436,Mind Riot
+1342543765,Ampeg Mule
+1342545132,Ferahgo's mule
+1342545824,Ferahgo the assasin
+1342546743,Gandalf Grey
+1342547755,Brother Trevor
+1342556511,Juliana Bravehart
+1342557104,Kara Sue
+1342557106,Lisa Grace
+1342557107,Carrie Lynn
+1342557108,Theressa
+1342558511,Emulio
+1342560526,Stargren III
+1342560837,Yo Yo Yo Yo
+1342563021,Arkai
+1342566338,D'hm Bulb
+1342568316,Oykib's Alchemist
+1342569462,Shackleton
+1342569516,Yasmina al-Shamir
+1342571072,Squire Juliana
+1342572259,Dracon
+1342572265,Blade
+1342572923,Quick
+1342573782,X-force
+1342574254,Iodized Salt
+1342574622,Wahooka the Great
+1342579287,Malchir
+1342585330,Frost's Alchemist
+1342585674,Seagryn
+1342589188,Jesse the Destroyer
+1342595263,Ulfang
+1342596079,Ridley
+1342598908,Fizz Two
+1342598918,Heero-Yuy's Slaveman
+1342602465,Zombi
+1342602652,Notsher
+1342602660,Lemmeno
+1342602663,Nokando
+1342603100,Cow The Cooker
+1342604862,Kryx
+1342605192,Pugilatrix
+1342606709,Roxx
+1342607014,Kritical
+1342608822,Asa
+1342611298,Corran Li
+1342612287,Ragarnok
+1342612303,Nova Weapon
+1342614110,Declan al-Maya
+1342615087,Haga
+1342617715,Lil Prob
+1342620145,Heero-yuy II
+1342620788,Bossman the Big
+1342620788,Dakkon Blackblade
+1342621913,Neds Atomic Dustbin
+1342621946,Vernish
+1342623123,Osis
+1342624423,Lisa Grace
+1342624425,John David
+1342624426,Lisa Grace Cole
+1342624552,Eichy III
+1342624774,Eichy IV
+1342624938,Eichy VI
+1342624939,Eichy VII
+1342630936,Faramyr
+1342632215,Kamikaze Kid
+1342632973,Gw the Swiftkiller
+1342634396,Funktacular
+1342635000,Ogg Jr
+1342637352,Gibsun II
+1342637872,Fegis
+1342638361,Scwarlock
+1342638730,Johnny d
+1342638781,Ken johnson
+1342638782,Kara sue
+1342638783,Ian fisher
+1342640550,Lisa grace
+1342640551,Johnny d
+1342640552,Carrie lynn
+1342640553,Kara sue
+1342640554,Lisa grace cole
+1342641129,Scwarlocks mule
+1342641273,Dark'Magic
+1342642440,Interim Mad Axe
+1342644320,Yakana
+1342644518,Stargren
+1342648243,E
+1342648334,Fizzle Brokenwand
+1342649582,Aralcarin
+1342651263,Scwarlocks muleii
+1342652882,Deadbolt
+1342652883,Al Mule
+1342653595,Ex-Sent Ripley
+1342655186,Lisa grace
+1342660171,Notsher
+1342660462,Evil Magestic
+1342660984,Battle Mage
+1342661452,Cow's Mule
+1342663469,Keiran Li
+1342663805,Jungle Souljah
+1342665051,Scwarlock's muleiii
+1342665480,Stargren Part Deux
+1342666387,Slims new guy
+1342666779,Dieter the Black
+1342669184,Dwynna
+1342671933,Chef's Salty Chocolat
+1342677529,Mr Mix-It
+1342678173,Darunia the Slayer
+1342682357,Pahd mod Pahd-el
+1342683632,The Fallen
+1342685130,Ingmar
+1342688763,Veylow
+1342689120,Ninavie
+1342691093,Cuddly Rabbit
+1342692275,Shadow Avatar XV
+1342692375,Plush Tusker
+1342694204,Synder
+1342696477,Arie
+1342696490,Killarwolf
+1342700863,Ho Be-Min
+1342703700,Random Chaos
+1342704908,Fibromyalgia
+1342705221,Straharik
+1342705750,Ho Be-Min's Runner
+1342709435,Ho Lin
+1342713146,Test Dt'gharubow
+1342713149,Test Dt'shosword
+1342713155,Test Dt'gharumule
+1342714974,Dave's not here
+1342715686,Frostwind
+1342716353,Miss Fizzel
+1342718597,Scout Drone Mk II
+1342719395,Miab Urro
+1342719929,Kilzeer
+1342720005,The Dreamer
+1342720060,Klatu Verata Nicktoo
+1342720107,The Woodsman
+1342723059,P S Y C H O
+1342725843,Sidhartho
+1342726055,Ua masterman
+1342727958,Fat slim I
+1342728486,Khandra al-Arrr
+1342728503,Keoki's Tinkerer
+1342736276,Chi'En Ching Lung
+1342739298,Acadia
+1342740547,Khandra
+1342740687,White Flare
+1342741106,Rusk
+1342743250,Koko Pele
+1342746788,Kozma
+1342749113,Stargren II
+1342749115,Stargren III
+1342749236,Stargren IV
+1342749238,Stargren
+1342750361,Miach
+1342753073,Immortalbob
+1342754798,Kumalo
+1342754882,D I S T U R B E D
+1342755441,The Mustafa
+1342759686,Bossman's Skillster
+1342760115,Cygmus
+1342766320,Saro
+1342770336,Rylyn
+1342771394,Zedura
+1342771512,Tropica
+1342772034,Carbuncle
+1342772519,Phantom Sight
+1342772582,Scrappy Dooo
+1342772585,Mr Lagg
+1342772587,Hippie the Treehugger
+1342772590,Mullet Master II
+1342772591,Charles Barkley
+1342774393,Josh the Destroyer
+1342774999,Lycentia
+1342777376,Quick Silver
+1342777524,Ikon Blade
+1342781240,Xedura
+1342781304,Antaios
+1342782773,Shady Mule
+1342783025,Velveteen Olthoi
+1342784398,Kreapist
+1342785829,Evil's lil Si Chest
+1342788162,Elluwak Meteu
+1342791712,Kryst al'meth
+1342793037,El Perro Caliente
+1342794612,Whatcha want
+1342795556,Genacide
+1342795845,Crog
+1342796353,Draco Malthoi
+1342796731,Magus the Dark
+1342796855,Oblivious
+1342797132,Eich
+1342799533,Dark Corsair
+1342799809,Saori
+1342799932,Railstan
+1342801896,Frazteak
+1342802120,Taisara
+1342802127,Erroneous
+1342806659,Bascule
+1342807732,Deathspawner
+1342808663,Phoxshot
+1342811053,Heeromuleii
+1342811819,American Zero
+1342813192,Ayza
+1342814022,Mozart's Requiem
+1342814975,Ripley
+1342815056,Arrow of the Dark
+1342816094,Syclones
+1342816952,Mixme
+1342816977,Ekime
+1342818999,Awullsu Quenisquney
+1342819610,Darkshot Dragoon
+1342820976,Faramyr
+1342820995,Zarkard
+1342822780,Nineveh
+1342824599,Pops
+1342825126,Gandalf the Pink
+1342825128,White Charles Barkley
+1342825789,Narcotic
+1342826002,Galaxian
+1342826683,Chatlin
+1342829312,Poison the Well
+1342829958,Ulala
+1342831260,Tylane
+1342831552,Ultramega
+1342832939,M U L E
+1342833174,Galadrim
+1342833187,Killerwolf one
+1342833188,Killerwolf two
+1342833189,Killerwolf three
+1342833194,Killerwolf five
+1342833195,Killerwolf four
+1342834542,Pick-it
+1342834610,Sammet
+1342836288,Admon's Peace
+1342836837,Oh Gee Mage
+1342837194,Required Input
+1342838598,Imhotep Amun-Ra
+1342840224,Takamine
+1342840299,Junias Bravehart
+1342841935,Dtassassin
+1342842474,Max Illidge
+1342842529,Ary'anna
+1342842583,Chaos Reigns
+1342842584,Supreme Chaos
+1342842586,Conflict of Interest
+1342842588,Triple Ex
+1342843153,Nod the Mule
+1342846062,O-Ren Ishii
+1342848644,Fugginay
+1342848769,Bow Duke
+1342852089,Uncle P
+1342852592,Esvectus
+1342852963,Teufel-Magie
+1342853657,Ignignokt
+1342853948,Junyper
+1342855203,Granis
+1342857570,Jina
+1342864128,Yangnom
+1342866589,Aliah the radiant
+1342866589,Bubble Boy II
+1342867234,Four Fifty Four
+1342869783,Black Bunnay
+1342870851,Dirty Dee
+1342871959,Taurin
+1342872038,Aerfalle's Mom
+1342872687,Xcar
+1342872887,Big Al Ho
+1342873181,Ahlindra
+1342873741,Gyer
+1342874164,Quarantine
+1342874166,Fighter of Foo
+1342875091,Twisted Tinkerer
+1342875157,The Bowsman
+1342875353,Coors Light Man
+1342875531,Coors Light Woman
+1342875770,Wilcot the Butler
+1342875837,Grady
+1342876084,Jsuy
+1342876115,Magic Man
+1342876342,Victor von Doom
+1342876527,Phoxsord
+1342877009,Cookies 'n' Cream
+1342877990,Ragarnok
+1342878222,Adair
+1342882415,Narkotik
+1342883383,Yi-like misue
+1342883657,Gfvkvkhb
+1342884364,Dave Dude
+1342884371,Heavy Set
+1342884844,I Don't Like Your Face
+1342889477,Kin Tama
+1342889789,Nadine
+1342891187,Eichy's Trade
+1342891511,Aliah mule
+1342892549,Alexisa
+1342893610,Eugene Levy
+1342894293,Cymry
+1342896022,X Killer
+1342896694,Tink al Ekim
+1342898221,John Bigboote
+1342898453,Jagermech
+1342898870,Deadly Chiapet
+1342900125,Tink R Belle
+1342900582,Sinarg
+1342900793,I Tink I Can
+1342904390,Rush Limbaugh
+1342904864,Wei lo-Down
+1342905929,Cyan Garamonde
+1342906283,Principal Blackman
+1342907840,Branor
+1342909078,Karn Aje
+1342909158,Torath Litson
+1342909951,Hei Shui
+1342909952,Jack The Swift
+1342910593,Test Noob II
+1342910595,Hanz Muleman
+1342910596,Hanz Muleman II
+1342910597,Hanz Muleman III
+1342910793,Test Noob
+1342911189,Mage of Bob
+1342911958,Chien Chaud
+1342912808,Iosep
+1342912993,Jerlan
+1342912994,Jerlana
+1342913379,Porcelina
+1342913953,Genacide X
+1342914023,Jack Litson
+1342916088,Mule Of Bob III
+1342916236,Turak
+1342916262,Tinker Bill
+1342917550,Abiathar
+1342917628,Stride
+1342917975,Phileas Fogg
+1342918388,Chueh Anne
+1342919958,Ryochu Xao
+1342920632,Yves
+1342920667,Whitworth
+1342920895,M U L E II
+1342921456,Meginjarder III
+1342921671,Dark Corsair
+1342921688,Meginjarder II
+1342921736,Snot Grumble
+1342922427,White Bunnay
+1342922536,Salvage holder
+1342924056,Io bhroigbha sdl hnfgaf
+1342924058,The Purple Monkeys
+1342924060,The Magic Nanners
+1342924061,L'l'l'l'l'l'l'l'l'l'l'l'l'l'l'
+1342924096,Vey
+1342924337,Flame Flame the Flame
+1342925278,Fat slim the bower
+1342925507,Idraea
+1342926489,John Malkovich
+1342929458,Enmos
+1342929536,Kwak
+1342929567,Delune
+1342929685,Cartoon Network
+1342929688,Rampart
+1342931421,Super Duper Quinn
+1342931482,Kurse
+1342932644,Born Supremacy
+1342934822,De Icer
+1342937102,Shootin' Blanks
+1342937104,Scoth
+1342937106,Clubbin
+1342937119,Walmart Salvage Department
+1342937237,Precious Metals
+1342937247,Kmart Salvage Department
+1342938221,Makosa'
+1342939433,Mariana K Dasher
+1342939671,Nozo's Mule
+1342939676,Hagreth
+1342940194,Phlogiston
+1342940403,Tristan the Fair
+1342940568,Guardian Mages
+1342941534,Mr Crossbow
+1342944400,Ogg Caveman
+1342944497,Krazy Karl
+1342946741,Deathreaper
+1342946813,Bob the Addlepated
+1342947020,Uzik of Crimson Stars
+1342949155,Huked on Fahniks
+1342949634,Dream Caster
+1342952913,Micke
+1342952954,Devssuxthisgameis Fu
+1342954705,Caffeine
+1342954707,Caffeine's Mule
+1342955124,Stuff Al-Maker
+1342955938,Atonement
+1342956138,Shoui
+1342957800,Immortal Spirit
+1342957988,Lost Kitten
+1342958009,L O C K P I C K A
+1342958272,Blackmoon
+1342959001,Platinum Chef
+1342961715,Stargren V
+1342961724,Meginjarder
+1342962342,Ibecookin
+1342962535,Scrollawlz
+1342963626,Tzhar
+1342964552,Esruk
+1342968837,Verdreht
+1342969165,Adx
+1342969633,Chic mule
+1342969636,Fizzle Brokenwand
+1342970134,Two Hand Luke
+1342970425,Keino
+1342970832,Bascule's Butler
+1342970935,Nemik
+1342970965,Etheldreda
+1342970975,Shattered Visions
+1342971122,Broken Halo
+1342971278,O-o
+1342971364,Egberta
+1342971437,Dwynna Wildshot
+1342971480,Ded En Side
+1342972053,Gyer
+1342972125,Camomille
+1342972566,Brittany'
+1342972763,Blood Loather
+1342972863,Devina
+1342973881,Nostradaemus
+1342974009,Darkmage O' Magic
+1342974570,Anonymous Alcoholic
+1342974918,Salvage
+1342975123,Little Lovebird
+1342975195,Amidala
+1342975486,Main Spring
+1342975508,Thor's Portal
+1342979021,Margulis
+1342979033,Pokn I Out
+1342979876,Pontus
+1342979993,Broccoli Wonderdog
+1342981728,Zanril
+1342982964,Sarak Vol Slim
+1342983131,Dodis
+1342983383,Rapt
+1342983393,Salvage Shop
+1342983694,Plumpy
+1342984971,Immortalbob II
+1342985111,Juliana Bravehart
+1342986019,Flagg'
+1342988711,Mishie
+1342989891,Royal Weapons
+1342990011,Nedless
+1342991008,Naimi
+1342992102,The Keeper of Scrolls
+1342992105,I keep the scrolls
+1342993488,Miach Raider
+1342993568,Luciferia
+1342993737,Sofia
+1342993977,Gundammule
+1342994005,Bearic Dondarion
+1342994006,Bluebetty
+1342994007,Chi-Lee Two
+1342994008,Hectorem Mortem
+1342994009,Biannca
+1342994010,Beyatrice
+1342995557,Acidic
+1342995863,Mosswart Enforcer
+1342996201,Beale
+1342996216,Ball-Dizzle
+1342997067,Beale II
+1342997549,Vandelai Silva
+1342998465,Geartooth
+1342998513,Chief Wifebeater
+1343000072,Spartan Atlas
+1343000213,Kricket's Poolboy
+1343000500,Danee
+1343000683,Ztg
+1343001104,Beale IV
+1343003010,Mulekime
+1343003043,Mulekime III
+1343003235,Zeeiholdcrap
+1343003385,Tradesman Miach
+1343003682,Punk N Drublic
+1343003700,Beale V
+1343004259,Mr Smile
+1343004266,Zeeee Armor Mule
+1343004579,Beale VI
+1343004603,The Internet
+1343004871,Im backing poo cakes
+1343004985,Mirrdin
+1343005230,Delubear
+1343005358,Khandra
+1343005364,Carry Bot
+1343005385,Sumik
+1343005434,Elcia
+1343005478,Mother mo fo mage
+1343005589,Ferio
+1343006049,Criminal Doge
+1343006169,Lunar Space Wizard
+1343006203,Diothe
+1343007554,Impeller
+1343007556,Mason's Salvage Mule
+1343007557,Mason's Armor Mule
+1343007559,Mason the Impaler
+1343007612,Mason's Deadeye
+1343007644,Psycho Slash
+1343007764,Ballz of Steel
+1343007843,Murdoch
+1343007941,Salvage Overflow
+1343008545,Fail Dye
+1343008928,Zee Di Holder
+1343009046,Yumioni
+1343009054,Yumichi
+1343009119,Mind the Void
+1343009120,Bombardment
+1343009121,Restitute
+1343009306,Hold my Sack
+1343010040,Average Square
+1343010489,The Scuba Squad
+1343010507,CW Rename
+1343010555,Sanguis Mortus
+1343010807,Astriella
+1343010877,Slims scroll mule
+1343011194,Fisherman Steve
+1343011521,Modi
+1343011645,Kwyjibo
+1343011718,Staid
+1343011827,Hatchet Harry
+1343012317,Kwy Trinket Salvage
+1343012577,Kwy Mule
+1343012587,Kwy Salvage
+1343012784,Beastie The Daemon
+1343013216,Fletchy McCooksalot
+1343013309,Slims archer
+1343014024,Fabricator
+1343014025,Quarantine
+1343014164,Zq Armor Mule
+1343014189,I R Teh Rox
+1343014209,Zq Wardrobe
+1343014234,Zq Steel Storage
+1343014235,Zq Brass Storage
+1343014283,Zq Weapon Locker
+1343014292,Zq Salvage
+1343014297,Kwy Wardrobe
+1343014356,Zq Salvage Overflow
+1343014537,Kwy Key Holder
+1343014800,Z Fifth Element
+1343015386,Hell's Wrath
+1343015480,Ze Overburdened
+1343015696,Kwy Salvage Overflow
+1343015892,Sanguis Volta
+1343015940,Vivi-Orunitia
+1343016169,Stromgard the Dark
+1343017634,Lisa G
+1343017635,Isabel Umana
+1343017636,Carrie Lynn
+1343017637,Karen Hjorten
+1343017721,Quarantined
+1343017728,Missing Pieces
+1343018026,Nakondas
+1343018027,Tiesto
+1343019252,Dooty Tang
+1343020923,Einherjer
+1343020948,Eldgrim
+1343021340,Eldgrim's salvage
+1343021403,Eldgrim's items
+1343021446,Antidisestablishmentarianist
+1343021448,Eldgrim Salvage II
+1343021538,Eldgrim Salvage III
+1343021553,Broncanuss
+1343022658,Vlakhen
+1343022703,Poeme
+1343023584,Ordall
+1343024513,Unlawful night
+1343025131,Ordall's mule
+1343025141,Blitzen II
+1343025451,Zad Storage
+1343025453,Zad zi
+1343025454,Zad Zii
+1343025457,Zad Notes
+1343025459,Zad Salvage
+1343025462,Zad Weapons
+1343025467,Zad Ziii
+1343025489,Zad Ziv
+1343025490,Zad Zv
+1343025693,Kung Fu Hamster
+1343025853,Eldgrim's Spirits
+1343025960,Makor
+1343025989,Sanguis Sparta
+1343026221,Kilemal
+1343027677,Statim Finis
+1343027801,Einherjer le II
+1343027856,Deathofac
+1343027857,Swampduckdaddy
+1343027891,Loo-Gie
+1343027926,Sabina Pasic
+1343027927,Isabel Umana
+1343027928,Randee Caras
+1343027929,Jessica Smith
+1343027930,Chelsea Case
+1343028747,Vv
+1343030538,Bullshtien
+1343030554,Kilemal
+1343030640,Maid in the Shade
+1343031102,Gotha
+1343031530,Warscrolls Keeper
+1343032393,Myarn
+1343032527,Akea
+1343032565,Kahil
+1343033203,Carline
+1343034477,Killing Foo
+1343035942,Beez Neez
+1343036179,Civinia
+1343037232,Sgt Smurf
+1343038099,Makors Mule
+1343038343,Holden Mygear
+1343040523,Nardwuar
+1343040688,The Big Mage
+1343040968,XXX Bow
+1343041640,Elysie
+1343041948,Turbo Wolf
+1343042153,Isaac the Swift
+1343042651,Callaway'
+1343044103,Gunghorin
+1343044155,Gotha
+1343044686,Another random druid
+1343045038,Little Thor
+1343045333,Georgeta
+1343045349,Thors Mule
+1343045371,Titatium
+1343045442,Elliut
+1343045836,Killarwolf
+1343045872,Rogueanna Deerhart
+1343046096,Televangelist
+1343047402,Jon Burro
+1343047936,Lil magnus
+1343047950,Gabrielle of The North
+1343048243,Toy Scuba Steve
+1343048248,Jagermech
+1343048567,Ingeborg
+1343049018,Scythien
+1343049096,Uncle Jake
+1343049152,Xarashadow
+1343049691,Redy
+1343049851,Moving Van
+1343049960,Fenney
+1343049990,Hold a bunch
+1343050455,Rumpy Stump
+1343051033,Hagreth's Mule
+1343051336,Zalia
+1343051398,Auna
+1343051479,Slim is the man says Ikon
+1343053144,Obey
+1343053305,Trym Dk
+1343053376,Triple Axe
+1343053403,Samina
+1343053823,Congo Natty
+1343053925,Old Rednose
+1343053949,Trym Og
+1343054311,Marauder II
+1343054465,Trym The Mule
+1343054525,Old Swordmaster
+1343054634,Asdfasdfasdfsadf
+1343054744,Etheldreda
+1343055320,Trym The Armorer
+1343055321,Trym The Smith
+1343055495,Heero-Yuy
+1343055496,Bowhunterman
+1343055498,Ogmageymage
+1343055499,Chy-Lee
+1343055500,Ms Sanya
+1343056567,Grandmaster Warren
+1343056826,Tinkering Foo
+1343057869,Trym The Slave
+1343057944,Old Brawler
+1343057945,Tickleme
+1343058342,Ticklemeto
+1343058540,Byte Size
+1343058909,Prophetofdreams
+1343059357,Heathkit
+1343059450,Sour Apple
+1343059533,Virulence
+1343060466,Boss Hog Of The South
+1343060895,Handy Smurf
+1343060997,Marth X
+1343061309,Dark Tyrael
+1343064077,Gabrielle of Tid
+1343064295,Black Butterfly
+1343064298,White Butterfly
+1343064383,Gabi's mule
+1343065782,Kurukar
+1343067143,Magica DeSpell
+1343069279,Fear Purple n' Red
+1343069804,God Of Wrath
+1343070093,Darq Cricket
+1343070184,Sad Sam
+1343071278,Nekromantix
+1343072338,Zoi
+1343073151,Viamontian Steel
+1343073368,Merenwen
+1343073480,Eirene
+1343073506,Chamie
+1343073532,Thalia
+1343074346,Ispahan
+1343074426,Dez'mron Moneychanger
+1343075195,Meren
+1343075273,Quickcut
+1343075994,Kochiro
+1343076892,Old Mad Man
+1343077430,Adultry
+1343078966,Valarie Tickles
+1343079003,No Pain No Gain
+1343079287,Nehmu ibn Wynd
+1343079288,Isgrim
+1343079719,Rodgers
+1343079888,Blizzard'
+1343081078,Kilemal
+1343081465,Maximum Fahrenheit
+1343081538,Little Ricardo
+1343081724,Baby Abby
+1343081808,Chats Mule
+1343081842,Hellarious
+1343082018,He who is called I Am
+1343082111,L E G E N D
+1343082297,Calous
+1343083138,Miach Justicar
+1343083147,Onikuma
+1343083206,Townsman Miach
+1343083496,Buff Bot Miach
+1343083900,Hollow Miach
+1343084012,Bob Loblaw
+1343084146,Gerryman
+1343084377,The Interweb
+1343084408,Miach Unleashed
+1343084590,Mister choop
+1343084721,Sorry Ibn Drinkin'
+1343084956,Vn Spacelord
+1343085550,Sunrise Adams
+1343086567,Falkeye
+1343087113,Shojunc
+1343087625,Drunkin Soul
+1343088042,Vlakhen
+1343088114,Rian di Falca
+1343088176,Pvt Licker
+1343088240,Blixten
+1343088300,Dez'mron Salvager
+1343088391,Bloodsausage
+1343088565,Hobbie
+1343090574,Gaby's Daughter
+1343091413,Makidi
+1343091435,Hagreth's Storage
+1343091437,Nozo's Storage
+1343091543,Box Top
+1343091567,The Arch Killer
+1343092190,Arzon Roak
+1343092495,Logan Doom
+1343093075,Al Bow
+1343093821,Fquick
+1343093904,Fquick Ua
+1343093917,Sheetguys
+1343094041,Deadmau
+1343094090,Morak Karuzi
+1343094252,Sho Can Tinker
+1343094282,Mag-nus
+1343094300,Beale VII
+1343095253,Digiorno
+1343095706,Fquick Salvage
+1343096155,Jin-Sung
+1343096174,Bowmaster Roland
+1343097349,Heritage Skillz
+1343097428,Sanguis Lazarus
+1343097625,Anotha Mule
+1343097992,Mag-tinker
+1343098202,Leldaran
+1343098228,Yellar
+1343098235,Mag-bow
+1343098888,Mag-mules
+1343098910,Mag-mule
+1343099056,Di items
+1343099149,Ldy of the blue lagoon
+1343099403,Mag-salvager
+1343099406,P E R T U R B E D
+1343099782,Chocolate Thriller
+1343099983,Blue Da Ba Dee
+1343100156,Peace Mezzir-Garrett
+1343100201,Interplanetary Delivery Man
+1343100325,John Fogerty
+1343100338,Sun Runner D'Aerth
+1343100441,Kitsune Loreweaver
+1343100713,Sun Mule One
+1343100854,Fquick Armor
+1343101011,N a r c o t i c
+1343101356,Dollar General
+1343101513,Peace Mule One
+1343101549,Blade of Memory
+1343101795,Footaki
+1343102433,Greifer
+1343102817,Einherjer
+1343102990,Koji Incarnate
+1343103379,Brodude
+1343103442,Beale VIII
+1343103645,Peddler Dragoon
+1343103920,Fedaykin
+1343103957,Captain Dudeface
+1343103963,Notouching
+1343104161,Holden Mai'villa
+1343104435,Tory Lane
+1343104578,Metalocalypse
+1343105110,Cyborg Sausage
+1343105154,The Drudge Mule
+1343105162,Furosuto
+1343105324,Ieatsalvage
+1343105799,Walk in closet
+1343105943,Beale IX
+1343105993,Deathdualer
+1343106077,Backpac
+1343106113,Fwank
+1343106265,That name is not permitted
+1343106297,Katherine Maree
+1343106343,Buymethings
+1343106465,Wally World
+1343106549,Ironbound
+1343107299,Tryme Idareya
+1343107713,Bro-A-Palooza
+1343107900,Ein's luggage
+1343108552,Grunk Dimp
+1343109067,PL Rename
+1343110286,Cedex
+1343110335,Fear My Power
+1343110396,Coheedandcambira
+1343110400,Coheed and cambira
+1343110401,C and ca stuff maker
+1343110762,Deathmule the First
+1343110795,Sticky Situation
+1343111160,Mag-lite
+1343111324,Ton Nen-Kai
+1343111449,Cheaper Colosseum Vendor
+1343111513,Affirmative Action
+1343111516,Beale III
+1343111562,Fquicker
+1343111566,Deathumbra
+1343111654,Lieutenant Dan
+1343111711,Shan-Shan
+1343111783,Mag-aetheria
+1343111784,Mag-armor
+1343111785,Mag-misc
+1343111786,Mag-money
+1343111788,Mag-salvage
+1343112102,Cams Mule
+1343112254,Martyr Al
+1343112384,Husmor
+1343112399,Deathquester
+1343112573,Dark pixie
+1343112760,Mag-Dis
+1343112916,Deathmule the Second
+1343112919,Deathmule the Third
+1343113066,Mag-five
+1343113067,Mag-six
+1343113068,Mag-seven
+1343113351,Mag-armor good
+1343113397,Cute'
+1343113494,Mag-ivory
+1343113514,Minnidil
+1343113701,Mag-brass
+1343113702,Mag-iron
+1343113703,Mag-granite
+1343113864,Mag-leather
+1343114095,Mag-steel
+1343114156,Thou Shall Not Fall
+1343114396,Mag-armor low al
+1343114489,Kyriel
+1343114766,Jonny Quest
+1343114861,Deathgearer
+1343114934,Throwbot Fivethousand
+1343115435,Little Maja
+1343115565,The Scuba Squad
+1343115605,Mag-cov salvage
+1343115647,Mag-dbl majors
+1343115648,Mag-epic jwlry undr
+1343115654,Mag-steel two
+1343115725,Mag-steel three
+1343115784,Mag-swords
+1343115785,Mag-wands
+1343115791,Mag-armor good def
+1343116547,Mag-Colo Rings
+1343116569,Mag-Tinkers Set
+1343116804,Mag-misc weapons
+1343116805,Mag-misc set pieces
+1343116875,Talliwacker
+1343116933,Biggy Shorty
+1343116934,Bad Bitty
+1343117033,Mule Squared
+1343117138,Mag-misc jwlry undr
+1343117225,Mag-Colo Items
+1343117239,Bladefear
+1343117495,Elmstreet Horror
+1343117613,Dayman
+1343117698,Nikara
+1343117700,Manza
+1343117972,Itty Bitty Titty Committee
+1343118039,Thrillhouse
+1343118785,Oh God It Burns
+1343120057,Mag-temp a
+1343120520,Mag-stuffs
+1343120711,Deathvoider
+1343121441,Panty Sniffer
+1343122362,Slims big guy
+1343123169,Interplanetary
+1343123318,Pininfarina
+1343123964,Treselle the True
+1343124089,Old Stuff
+1343124254,I Hate This Job
+1343124767,Yoroi Orange-Gold-Black-Purple
+1343124769,Yoroi Red-Green-Blue
+1343124787,Beale X
+1343125455,Rollie Wedge
+1343125863,Asfasf
+1343125951,Messer's Revenge
+1343126047,Mezzer
+1343126349,Nozo's Mule II
+1343126529,Meseria
+1343127170,Box Top's Twin
+1343127292,Trader Dagger
+1343127720,Hagreth's Twin
+1343127943,Shomage
+1343128026,Deathweaper
+1343128028,Deatharmorer
+1343128087,Ticklemethree
+1343128112,Ticklemefour
+1343128127,Ticklemesix
+1343128208,Ticklmeeight
+1343128914,All Tickled Out
+1343129363,Gwendolyn du Avalon
+1343130039,Chief of Staff
+1343130040,Jim Bowie
+1343130042,Vitae-man
+1343130735,B-Afraid
+1343131381,Miach Champion
+1343131431,Miach Oppressor
+1343131443,Saosinn
+1343131495,Brutalis
+1343131774,Logan slim
+1343132417,You so nozey why you spy on me
+1343132713,Blue Shaman
+1343132878,Entropy Guy
+1343132953,Decal C-Sharp Dev-bot
+1343132953,Lifestone Shaman
+1343133073,The deceiver
+1343133181,C tan
+1343133747,Beale XII
+1343134006,Luginut
+1343136086,Death the Devoid
+1343136945,Slimette
+1343137258,Elizebeth
+1343137762,Franks and Beans
+1343137863,Thirteen'
+1343138843,A Courier
+1343139263,Izboy
+1343139438,Hundreng Scytheson
+1343139720,Baeelzhaarons
+1343140413,Zino
+1343142119,Nuke'em
+1343142134,Bow Flex
+1343142709,Punchster
+1343142971,Legendary Delivery Boy
+1343143005,Kottonmouth King
+1343143046,Belladona
+1343143799,Johnny Richter
+1343143799,Mayday parade
+1343144301,Ivel
+1343144304,I Throw Stuff At You
+1343144646,Metal Slime
+1343144729,Minari
+1343144897,Superconductor
+1343145040,Thirteen Blades
+1343145094,Forever Knight'
+1343145095,The Scarlet Blade
+1343145114,Super Duper
+1343146393,Hairy Muldoon
+1343146399,Ya Dig
+1343146710,Lazy Eye Miach
+1343146866,Guardian Miach
+1343146869,Miach Smurf
+1343146912,Smurf Miach
+1343146914,Bow Miach
+1343146915,Miach Bow
+1343146916,Blind Miach
+1343147338,Mulemand
+1343148531,Shady Gaga
+1343148922,Mule II du Gwendolyn du Avalon
+1343149451,George Fisher
+1343150674,Trym Ny
+1343150723,Onde Lyne Mig
+1343150981,Sam the Shiv
+1343151253,Copastetic
+1343151444,Storage IV
+1343151588,Storage V
+1343151593,Beale's Spell Components
+1343151594,Krasch
+1343151639,Beale's Quest Items and Misc
+1343151654,Beale's Armor
+1343151655,Beale's Random Salvage
+1343153513,Flash Strike
+1343153514,Flesh Strike
+1343153926,Miss Marvel
+1343154582,Gov
+1343154720,Canis Majoris
+1343155107,Coversationalist
+1343155293,Ho Mule
+1343155713,Fatass
+1343157160,Ghost of Aimaru
+1343157283,Johan van der Smut
+1343157321,Lili Von Shtupp
+1343157330,Weapon Delivery Boy
+1343157331,Legendary Delivery Boy II
+1343157451,Fiktion
+1343157896,Bash Masterson
+1343158114,Kaika
+1343158116,Legendary Delivery Boy III
+1343158117,Tailoring Dude
+1343159094,Black Mist
+1343160073,Legendaries
+1343160748,Steelmule
+1343160907,Steel mule II
+1343160929,Kitz n Shiz
+1343160930,Chest one
+1343160931,Chest two
+1343160932,Chest three
+1343161013,Steel for Sale
+1343161496,Sos Piet
+1343162118,Deathconjurer
+1343162285,Nig Nog
+1343162770,Aeriloa
+1343162877,Deathmule the Fourth
+1343162878,Deathravager
+1343162879,Deathmule the Fifth
+1343162890,Grammar Nahsi
+1343162893,Deathmule the Sixth
+1343162894,Deathmule the Seventh
+1343163000,Deathmule the Eighth
+1343163019,Deathmule the Ninth
+1343163020,Deathmule the Tenth
+1343163075,Jylie Braveheart
+1343163077,Deran Dark
+1343163272,Smasha
+1343163283,Grungeon
+1343163319,Gruedor The Troubadour
+1343163348,Gniyfingam Ssalg
+1343163382,Pachi
+1343163738,M U L E III
+1343163925,O-Too
+1343163950,Goober The Doober Smoozer
+1343163952,Muledorf
+1343163953,Greudon The Muledon
+1343164087,Esmarelda Morleigh
+1343164215,Groober The Noober
+1343164586,Aerboa Clanoa the Crying Sandtoe
+1343164819,Draknor Knightbane
+1343165088,Mega Salvage Mule
+1343165092,Mega Misc Mule
+1343165530,Weapontinksal
+1343165808,Old Spacelord
+1343165972,Chest five
+1343166731,Colost
+1343166733,Booom Booom
+1343166821,Go Boom Boom
+1343166822,Rock for brains
+1343167197,Void Einherjer
+1343167271,Lucifers' Prodigy
+1343167323,Spadone
+1343168431,Algorab
+1343168920,Mule du Gwendolyn du Avalon
+1343169247,Fericci
+1343169817,Ironhands
+1343169819,Sparkfist
+1343169826,Omglazerz
+1343169847,Mahharu
+1343169939,Blonde Smurf
+1343169957,Hermitboy
+1343170096,Deathpoker
+1343170141,Xao Mah
+1343170230,Ripvanwinkle
+1343170292,I Like Big Bots
+1343170297,Cold Knight Storage
+1343170353,Sacrificial
+1343170374,Deathmule the Eleventh
+1343170547,Jonsuxpp
+1343170637,Hayate Ayasaki
+1343170685,Deadite
+1343170687,Mahh Spellz
+1343170760,Shangtsung
+1343170903,Heldgrim
+1343171078,The Tenderizer
+1343171091,Deletorious
+1343171570,Smurfs Allot
+1343171694,Nahamston
+1343171815,Schala du Avalon
+1343172279,Boidomeiji
+1343172419,I Call Him Leggs
+1343172455,Constance Green
+1343172729,Peppah
+1343173241,Splitshaft
+1343173265,Quintillus
+1343173372,Chest four
+1343173451,Horrideus
+1343173641,Sanguis Tenebrous
+1343173644,Caerlean
+1343173689,Apsu
+1343173755,Elsydeon
+1343173756,Fiona Starcaster
+1343173758,Shau'ri Starshard
+1343173781,Amin Ra
+1343173886,Elyssa Nightbane
+1343173936,Deathmule the Twelfth
+1343173940,Deathmule the Thirteenth
+1343174118,Gear Kweer
+1343174305,Sanguis Sitis
+1343174461,Insert coin
+1343174539,Diogenes Pendergast
+1343174555,A'mee
+1343174619,Furota
+1343174634,Mrs Grey
+1343174655,Beale's Wands
+1343174659,Beale Bows
+1343174663,Miss Blue
+1343174668,Kara Zor-El
+1343174761,Lunette Xylia
+1343175064,Gelidite
+1343175072,Iron Chef Akal
+1343175139,Hitachino
+1343175395,The Drudge Mule III
+1343175478,Hiro Blademaster
+1343175508,Tuff Shed
+1343175560,A Blacksmith
+1343175769,Akal Saris
+1343176118,Dragula
+1343176359,Mule of Ripley
+1343176511,Beale's Summons
+1343176517,Beale Steel
+1343176518,Beale Brass
+1343176622,Derpa derp
+1343176642,Vey lamule
+1343176986,Perrin al'Thor
+1343177206,Fortunato di Fausto
+1343177207,Beale's Weapons
+1343177209,Beale's Shadow
+1343177211,Beale XV
+1343177212,Beale's Di Items
+1343177252,Beale's Ivory
+1343177267,Beale's Brass
+1343177268,Beale's Colored Yoroi
+1343177269,Beale Green Garnet
+1343177376,Beale Steel II
+1343177600,I Hold Items
+1343177645,Cryptic Storm
+1343177838,Cosmic Microwave Background
+1343178046,I Hold Stuf Too
+1343178047,Item Mule
+1343178048,Item Mule III
+1343178050,Item Mule V
+1343178052,Item Mule VII
+1343178053,Item Mule VIII
+1343178113,The Drudge Mule IV
+1343178191,Inky Shadow
+1343178243,Beale's Underclothes
+1343178252,Beale's Quest Items
+1343178256,Beale's Bank
+1343178390,Beale's Colored Yoroi II
+1343178533,Dot Dot Dot
+1343178664,B E A L E
+1343178665,Vinnie Paz
+1343178678,Beale's Ivory II
+1343178714,Slayer Miach
+1343178932,Beale Bows II
+1343178934,Beale's Wands II
+1343178935,Beale's Trinkets
+1343178936,Beale's Rares
+1343178939,Beale's Cloaks
+1343178942,Beale's Rings
+1343178944,Beale's Bracelets
+1343178945,Beale's Mahogany
+1343178947,Beale's Wise Set
+1343178948,Beale's Trinket Salvage
+1343178967,Beale's Leather
+1343178968,Beale's Adept Set
+1343178969,Beale's Defender Set
+1343178970,Beale's Dex Set
+1343178973,Beale's Aetheria
+1343179164,Aestourn
+1343179212,Nano diablo
+1343179227,Kama Koze
+1343179227,Welldang
+1343179342,Rank Void
+1343179650,Salvatore Folgeretti
+1343179856,Muleylugey
+1343179858,Yar
+1343179898,Ironn Man
+1343180421,Darth Crash
+1343180422,Darth Klatu
+1343180429,Hermit Lord
+1343181297,Two killer
+1343181298,Tufor Thesho
+1343181374,Armor Designs
+1343181420,Beale Ivory III
+1343181422,Beale Steel III
+1343181434,Verata Lord
+1343181529,Gear Al
+1343181532,Beale Ivory IV
+1343181533,Beale Ivory V
+1343181559,Beale Diamond Powder
+1343181769,Beale XX
+1343181783,Beale Temp Storage
+1343181786,Beale Temp Storage II
+1343181787,Beale Temp Storage III
+1343181788,Beale Temp Storage IV
+1343181789,Beale Temp Storage V
+1343181790,Beale Temp Storage VI
+1343181791,Beale Temp Storage VII
+1343181794,Beale Temp Storage VIII
+1343181796,Beale Temp Storage IX
+1343181797,Beale Temp Storage X
+1343181798,Beale Weapon Skins
+1343181880,Carlos Danger
+1343181888,Beverlyanne
+1343182032,Beale Colo Rings
+1343182037,Beale Colo Rings II
+1343182133,Beale Weapon Skins II
+1343182145,Beale Mansion Kit
+1343182162,Ailea
+1343182178,Beale's Underclothes II
+1343182235,Arrtoo Deetoo
+1343182239,Beale Moonstone
+1343182240,Beale's Wands III
+1343182241,Beale's Weapons II
+1343182243,Beale Colo Rings III
+1343182244,Beale Colo Rings IV
+1343182252,Beale Bows III
+1343182254,Beale Colo Rings V
+1343182255,Beale C Temp
+1343182282,Beale Necklaces
+1343182298,Beale Ten Tink Armor
+1343182460,Beale Colo Rings VI
+1343182471,Scel
+1343182488,Harambe
+1343182549,Nocc Temp
+1343182561,Some Salvage
+1343182592,Encap Spirits
+1343182610,Obama Care
+1343182611,Slapchop
+1343182644,Trash Panda
+1343182710,Proms
+1343182754,Hitlore
+1343182885,Eight Foot Freak
+1343182893,Kronos Lord
+1343182949,Totes lit fam
+1343182986,Dwight Schrute
+1343183047,Armadillo
+1343183051,The Last Portal
+1343183052,Brialmont
+1343183060,Simgear
+1343183114,Tunzi
+1343183143,Greg Graffin
+1343183179,Celph Titled
+1343183180,One Last Skree
+1343183184,Deathbower
+1343183188,Ghjhhtyutru
+1343183194,Isabel Umana
+1343183196,Heather Downey
+1343183197,Liz Bouiss
+1343183198,Cristina Herrera
+1343183199,Karen Hjorten
+1343183200,Gita Stephan
+1343183266,Bliz Eno Renard
+1343183785,Griij the Alkemyst
+1343184151,Santa Bob
+1343184209,Cimmerian Shade
+1343184407,Doubletap
+1343184433,Doom Man
+1343184607,The Drunken Dagger
+1343184687,Flex Buffchest
+1343184702,Pubbie James
+1343184710,Daisy Pushover
+1343184748,Putrefy
+1343185102,Erebos
+1343185171,Mechanism
+1343185195,Shade of Legato
+1343185205,Patrick Darkarrow
+1343185796,Burfen
+1343186046,Xoatl
+1343186169,Yolandi Visser
+1343186237,Courage Wolf
+1343186604,Mantis Toboggan
+1343187021,Koverasi
+1343187198,Maelwig
+1343187688,Blodcniht
+1343188158,Dkoreas
+1343188159,Kiri bint Saris
+1343188529,Wuldor
+1343188955,Dez'mron Armory
+1343189038,The Drudge Mule V
+1343189293,Darkk Valyn
+1343189879,Tarball
+1343189900,Drumbeater
+1343190264,Gerod
+1343190271,Darq chocolate
+1343190293,Cartimandua
+1343190410,Raukowath
+1343190434,Kurathzia
+1343191381,Dez'mron Armorer
+1343191382,Dez'mron Smithy
+1343191383,Ranlyn
+1343191384,Somilar
+1343191385,Dez'mron Loremaster
+1343191399,Dez'mron Trader
+1343191400,Marek Vagnard
+1343191401,Feral Intendant
+1343192696,Cait Sidhe
+1343192799,Aun-Festivus
+1343193128,Bliz Renard
+1343193408,Help i don't know how to exit th
+1343193415,Embertide
+1343193486,Speppy bringus
+1343193814,Syrup
+1343193889,The Drudge Mule VI
+1343193891,The Drudge Mule VII
+1343193892,The Drudge Mule VIII
+1343193893,The Drudge Mule IX
+1343193894,The Drudge Mule X
+1343194769,Meet Your Doom
+1343194804,Deeza
+1343194913,Gwolchming
+1343194972,Into The Abyss
+1343195125,Abahl
+1343195214,Eryx
+1343195307,Tehmoole
+1343195425,Blueberry'
+1343195427,Aeryx
+1343195544,Tiderius
+1343195545,Arbitar
+1343195894,Flashyflash
+1343195943,Love'
+1343196092,Deeza's Mule lol
+1343196235,Jimmytehhater
+1343196237,Wuzzzzabing
+1343196277,Undead Courier
+1343196344,Deeza's Mule Two lol
+1343196394,Loogie Anne
+1343196476,Noigel
+1343196536,Hand of Doom
+1343196542,Tmone
+1343196590,Garthak
+1343196597,Snarfle
+1343196649,Frickin Fugly
+1343196840,Malleus
+1343197058,Aaroniero Arruruerie
+1343197060,Deeza's Mule Four lol
+1343197062,Keymaster
+1343197160,Treebark
+1343197199,Miss Doom
+1343197492,Large Packs
+1343197947,My Armor
+1343197951,So here's some gear
+1343198095,Hock a Lugi
+1343198096,Lugi Hocker
+1343198179,Jopen
+1343198950,My Gear
+1343199164,Bunnu
+1343199230,K'itara
+1343199430,Pack Space
+1343199844,Anastasia Steele
+1343200420,Sereg Palan
+1343201227,Top Tier Loot
+1343201732,Darq Perro
+1343202076,Caldwig
+1343202254,Aelmar Matisse
+1343202515,Russet
+1343202815,Grand Casino Chest
+1343203805,Mah Rocks
+1343203852,Peace Mg
+1343204520,M U L E IIII
+1343204530,Yam Festival
+1343204614,Mr A
+1343204620,Blazing Sun
+1343204950,Geggy Tah
+1343205181,Olthoi Bug
+1343205329,Spear Chuker
+1343205496,M U L E IIIII
+1343205630,Incantation of Components
+1343205828,Shadow of Liberty
+1343205954,Divertimento
+1343206029,Steel Mill
+1343206496,Stentorian II
+1343206591,X Bow
+1343206604,Dark Malzar
+1343206653,Axiom Rage
+1343206673,Void Summoner Eridyn
+1343206676,Zechar
+1343206690,Raxem
+1343206783,Spacelord le II
+1343206812,Eridyn at the End
+1343206820,Ash Anor
+1343206822,Axiomwin
+1343206835,Fuuucwb
+1343206889,Kayame
+1343206895,Salvaged Bone
+1343206896,Goodbyeac
+1343206897,Kuwashi
+1343206908,Hold my junk
+1343206928,Purpley Guy
+1343206939,Pleasantspecter
+1343206948,Fatslim
+1343206959,Shootey McWarwand
+1343206961,Heather Downey
+1343206962,Isabel Umana
+1343206963,Theresa Herrera
+1343206964,Liz Bouiss
+1343206965,Karen Hjorten
+1343206966,Cristina Herrera
+1343207321,Onceler
+1343208425,Rhien
+1343208474,Excessum
+1343208477,A T B
+1343208522,Arkai
+1343209393,Dread Blade
+1343209409,Winslow the Quick
+1343209681,M U L E VI
+1343210271,More Packs
+1343210387,Even More Packs
+1343210519,Joffrey
+1343211440,Rein of Darkness
+1343211619,Holder of 'da Goods
+1343211620,Legendary Barney
+1343211716,Pygoscelis
+1343211934,Kalashan
+1343212009,In Living Color
+1343212012,Grundaar
+1343212054,Mec Qui Tombe Dans L'Vide
+1343212261,I'm Another Pack
+1343212614,Blacksteel Golem
+1343212938,Aloysius Pendergast
+1343213470,Hoar
+1343213857,Kvothe
+1343213924,Vashet
+1343214780,Cyberkiller
+1343215098,Bunnec
+1343215740,Tinkertron
+1343215801,Legacyholder
+1343215943,Zaras the Summoner
+1343217548,Myrrlin
+1343217646,Aleyn
+1343217819,Buffoon
+1343218051,Dolt
+1343218054,Dimwit
+1343218201,Bob's Rare Mule
+1343218202,Bob's Aetheria Mule
+1343218251,Bob's Item Mule
+1343218304,Bob's Spell Comps
+1343218923,Bob's Armor Mule
+1343219975,Rosewhine
+1343220042,Zometh Hypemist
+1343220064,Elite Wares
+1343220239,Skrilex
+1343220328,Void Al
+1343220394,Gais
+1343220613,Muleington
+1343220631,Xanxin
+1343220710,Reverse osmosis
+1343220721,Muleingtoni
+1343220843,Dummy
+1343220844,Numb Skull
+1343220845,Dullard
+1343220891,Chat Mule
+1343220900,Elite Wares II
+1343221088,Celeth
+1343221089,Blvit
+1343221089,Elite Wares III
+1343221188,Muleington the third
+1343221346,Dis R Us
+1343221527,Xioxin
+1343221528,Lummox
+1343221529,Chowderhead
+1343221537,Thick
+1343221547,Kaean
+1343221673,Bob's Quest Armor
+1343221707,Kaiju
+1343222041,Bob's Foolproof
+1343222042,Bob's Attic
+1343222043,Bob's Crafting Supplies
+1343222098,Bob's Cloaks
+1343222102,Bob's Tailoring Mule
+1343222103,Bob's iewelry Mule
+1343222104,Bob's Quest Weapons
+1343222109,Safe Deposit Box
+1343222144,Mulegbg
+1343222254,Pushu
+1343222255,Pushu Tuu
+1343222389,Pacipaw
+1343222652,Belizu
+1343222653,Litle Girl
+1343222654,Daidarabotchi
+1343223502,Strong Arm Numb
+1343223671,Phantasi
+1343223907,Chuchu Chizen
+1343224440,Limondir
+1343224777,Ciel Cadelanne
+1343225697,The Skuggan
+1343225874,Ripley's Resurrection
+1343226029,Winter Fennec
+1343226030,Eli Sharpclaws
+1343226034,Yamaguchi Tsutomu
+1343226457,Liamh
+1343226628,Kaleja
+1343227361,The Drudge Mule XI
+1343227365,Exchequer
+1343227717,Mads
+1343227970,The Drudge Mule XII
+1343227973,The Drudge Mule XIII
+1343228128,Gold Hold
+1343228164,Arkaina
+1343228296,Cheleth
+1343228480,Liman
+1343228524,Khatina
+1343228528,Daiki
+1343228661,Sommar
+1343228830,Akatsuki
+1343228831,Nh Rep
+1343228993,Hub items and gold letters
+1343229653,Tidedoom
+1343229742,Caveman Rare Holder
+1343229861,Bob's Brass
+1343229897,Ugly the Caveman
+1343229903,Bob's Finesse Weapons
+1343229905,Bob's Heavy Weapons
+1343229907,Bob's Light Weapons
+1343229908,Bob's Wands
+1343229909,Bob's Missile Weapons
+1343229910,Bob's Two Handed Weapons
+1343229911,Bob's Summon Mule
+1343229917,Xyzzzzy
+1343229918,Xyzzw
+1343229921,Bob's Steel
+1343229927,Bob's Squire
+1343229949,Qarkai
+1343230091,Arkai's Mule
+1343230110,Old Hatter
+1343230271,Double A's
+1343230343,Zylkari the Armorer
+1343230395,Isolte
+1343230529,Caveman Quartermaster
+1343230608,Old Log the Axer
+1343230613,Trym The Hothead
+1343230620,Lamie
+1343230668,Arkaina's Mule
+1343230915,Clyde Arrowny
+1343231107,Aganaroth Teenager
+1343231230,Qarkai's Mule
+1343231302,Nugoh
+1343231429,Emulio'
+1343231468,Trym the Mage
+1343231473,Trym the Mighty
+1343231477,Old Goose
+1343231662,Kicki
+1343232335,Meduka
+1343232336,Disregard Gravity
+1343232340,Charone
+1343232341,Chartwo
+1343232344,Charthree
+1343232348,Charfive
+1343232350,Charsix
+1343232352,Charseven
+1343232354,Chareight
+1343232379,Avald Frosteye
+1343232639,Old Man Mose
+1343232875,Basmel
+1343232880,Lokei
+1343233094,Emulio Jr
+1343233436,Emblem Rhapsody
+1343233774,Trym The Clog
+1343233792,Enceladus
+1343233799,Preon
+1343233936,Hc Mode
+1343234297,Ark's Mule
+1343234348,Craftmaster Chrom
+1343234433,Arkaii
+1343234434,The Black Death'
+1343235027,Korrupt
+1343235106,Surefluff
+1343235233,Bigdumbluggie
+1343235265,Orwen
+1343235280,M U L E VII
+1343235636,Bunnu's Melee Weapon Mule
+1343235641,Bunnu's Useful Misc Mule
+1343235645,Bunnu's Other Weapon Mule
+1343235646,Bunnu's Legendary Skills Mule
+1343235648,Bunnu's Legendary Ward Mule
+1343235649,Bunnu's Armor Mule
+1343235650,Bunnu's Misc Mule
+1343235664,Bunnu's Equipment Mule
+1343235666,Bunnu's Armor Mule II
+1343235676,Bunnu's Armor Mule III
+1343235709,Bunnu's Misc Mule II
+1343235730,Bob's Keys
+1343235755,Katharin Pazzadea
+1343235857,Rinadu
+1343235886,Bob's Quest iewelry
+1343236213,Void Miach
+1343236514,Farlon
+1343236973,Bob's Green Garnet
+1343236974,Bob's Iron
+1343236975,Bob's Granite
+1343236976,Bob's Hog
+1343236977,Bob's Misc Salvage
+1343237249,Bob's Consumables
+1343237784,Yari Ashigaru
+1343237802,Ark's Fletcher
+1343238026,Colorful
+1343238564,Ark's Salvage
+1343238738,T B D
+1343239147,Yui Hirasawa
+1343239151,Nodoka Manabe
+1343239275,Gov's Mule
+1343239300,Cuddly Rabbit
+1343239388,Inferno Of Death
+1343239390,Velveteen Olthoi
+1343239710,Bob's Armor Mule II
+1343240325,Arie
+1343240387,Bob's Item Mule II
+1343240388,Bob's Attic II
+1343240410,Bob's Shields
+1343240414,Bob's Cloth
+1343240415,Bob's Temp Mule
+1343242659,Aridack
+1343242696,Fluffiest Bunny
+1343243723,Snowypaws
+1343244193,O-Tugak Me
+1343244201,Casimiro
+1343244298,Shadowtwo
+1343244680,Stramus
+1343246898,Professor Bob
+1343247731,Duna the Dain
+1343247737,Main the Dain
+1343247745,Tain the Dain
+1343247764,Dulle the Hat
+1343247766,Give the Hat
+1343247767,Dina the Hat
+1343247769,Rain the Dain
+1343247788,Sanguis Necrosis
+1343247790,Sanguis Gigas
+1343247845,Gina the Hat
+1343247847,Lane the Dain
+1343247848,Thain the Dain
+1343247849,Line the Hat
+1343247850,Dima the Hat
+1343247889,Bob's Armor Mule III
+1343248266,Xantia the Hat
+1343248270,Xantia the Dain
+1343248607,Zacha the Hat
+1343248791,Bob's iewelry Mule II
+1343248943,Shaiky
+1343248997,Mr Steel Mule
+1343248998,Mr Brass Mule
+1343248999,Mr Rends
+1343249001,Mr Leg Armor
+1343249003,Mr Bling
+1343249004,Mr Leg Weps
+1343249005,Mr Noob Gear
+1343249006,Mr Random
+1343249022,Mr Loot
+1343249050,Vektor
+1343249084,Sho Slave
+1343249192,Zenia the Dain
+1343249202,Zenia the Hat
+1343249222,Zentia the Hat
+1343249396,More Noob Gear
+1343249481,Brass Eye
+1343249514,Iron Granite
+1343249561,Mr Rares
+1343249629,Bob's Quest Armor II
+1343249793,More Steel
+1343249974,Randommm
+1343249975,Randommmm
+1343249976,Randomm
+1343249977,Randommmmm
+1343249978,Randommmmmm
+1343249979,Randommmmmmm
+1343249980,Randommmmmmmm
+1343249981,Randommmmmmmmm
+1343249984,Ramdong
+1343250011,T-Force
+1343250055,Deadshot Miach
+1343250056,Mage of the Void
+1343250057,Brute Miach
+1343250117,Deezhaha's Armor
+1343250205,Bob's Attic III
+1343250287,Im Poisonivy
+1343250343,Im Catwoman
+1343250504,Go Green
+1343250538,Altoids
+1343250716,Unattended Combat Macro One
+1343250758,Boopa di Snoot
+1343250852,Daicon
+1343250977,Key-ji
+1343251085,Zyzzy
+1343251086,Zyzygy
+1343251087,Zygomatic
+1343251138,Zana the Dain
+1343251139,Zara the Hat
+1343251196,Xerox the Dain
+1343251304,Away From Keyboard
+1343251305,Bathtub
+1343251381,Flinkif
+1343251606,Zyggy
+1343251607,Zygmund
+1343251952,Jhinna
+1343252348,Bob's Quest Weapons II
+1343252660,Port-A-Port
+1343254491,Boopa du Snoot
+1343254821,Fastest Two Seventy Five Ever
+1343254893,Mulesaa
+1343254894,Mulesab
+1343254895,Mulesac
+1343254896,Mulesad
+1343254897,Mulesaf
+1343254898,Mulesag
+1343254921,Mulesae
+1343254922,Mulesah
+1343255011,Z-Steelz
+1343255013,Z-Ironzmulez
+1343255105,Z-Housemulez
+1343255461,Claire Kanina
+1343255624,Green Taxi
+1343255627,Hydroptic
+1343255712,Blue Taxi
+1343255751,Red Taxi
+1343255825,Killerolthoi
+1343255884,Taxicab
+1343255905,Xel of Holt
+1343255954,Housing Mule
+1343255987,El Clasico
+1343256005,Ripley of Frostfell
+1343256006,Ragan the Clone
+1343256068,Headed to Shard Memorial
+1343256076,Aka-steve
+1343256079,Isabel Umana
+1343256098,Last day boys
+1343256127,Snowbunnec
+1343256137,Theresa Herrera
+1343256138,Carrie Vander Ven
+1343256139,Heather Downey
+1343256140,Kara Finch
+1343256141,Liz Bouiss
+1343257353,The Baron of Colier
+1343259270,Tabitha Stonebreaker
+1343259288,Dirty Lewdian
+1343261289,Arts n Crafts
+1343261291,Wub
+1343261379,Wubauri
+1343263539,Hamud ibn Rafik
+1343263618,The Drudge Mule XIV
+1343263619,The Drudge Mule XV
+1343263620,The Drudge Mule XVI
+1343263923,Eviction Notice
+1343263947,Burglar
+1343264226,Harlune the Misanthrope
+1343264535,Pulse Omega
+1343265138,Petty Theft
+1343265159,Grand Larceny
+1343265161,Robbin' da Hood
+1343265162,Slash Ann's Little Sister
+1343265385,Roid Rage
+1343265421,Garbage Disposal Unit
+1343265643,Tim Gunn
+1343267365,Frej
+1343267405,Tinker Toys II
+1343267425,Long John Silver
+1343267426,Pittsburgh Stealer
+1343267758,Miss Taken Identity
+1343268056,Alphabeat
+1343268613,Doombringor
+1343270995,A Wilhelm Scream
+1343271570,Drakenn
+1343272674,Ambiguous Ace
+1343273342,Amway Jane
+1343273344,Gibby Haynes
+1343274028,Tumescent Tumerok
+1343274029,Tuck Fard
+1343275121,Caerlean
+1343275482,Tuskapoo
+1343275484,Octavione
+1343275485,Octavitwo
+1343276379,Husband
+1343276592,Junk in the Trunk
+1343277074,Hugo Boss
+1343277255,Arm Er Awl
+1343277693,The Drunken Madman
+1343277697,The Guardian of the Lost Light
+1343277735,The Baroness of Colier
+1343277736,Colier Mine First Shift Foreman
+1343277740,Colier Savings and Loans
+1343277741,The Custodian of Colier
+1343277742,Colier Credit Union
+1343277783,Made Custom
+1343278110,Husband I
+1343278123,Husband II
+1343278135,Husband III
+1343278143,Husband IV
+1343278158,Husband V
+1343278173,Husband VI
+1343278182,Husband VII
+1343278197,Husband VIII
+1343278206,Husband IX
+1343278218,Husband X
+1343278225,Puttaren
+1343278916,Cripple Creek
+1343279277,Chief Mulebeater
+1343279436,The Scuba Squad
+1343282674,Daralin
+1343283173,Tingalayo
+1343285614,Manza
+1343285711,Malzar
+1343286120,Chevalier de Avaritia
+1343286202,Mcnoodle
+1343286866,Mmd General Store
+1343286989,Rupert Everton
+1343287005,Tinker McBaggins
+1343287902,Thirteen Blades
+1343290222,Jo-Lee Jheuh
+1343290911,Bytes
+1343291372,Warmech
+1343291498,Fghfghfgasz
+1343291499,Dereth Daily Deals
+1343291848,Gigabyte
+1343292051,Terabytes
+1343292804,Dieter The Black
+1343293368,Magic Trap
+1343293369,Rainbow Table
+1343293947,Eridyn of the Dark
+1343294834,Bytes Temp Mule
+1343294856,Artemis Clyde Frog
+1343295584,Mr Baker II
+1343295923,Dreams Mistress
+1343295924,Dreams Salvage
+1343296498,Petabyte
+1343297547,Mr Holds Alot
+1343297577,Kekeke
+1343298277,Malchir
+1343298677,Gfhjghjgyjhfg
+1343298822,Futz
+1343298826,Dshjklhgfd
+1343298831,I love rome
+1343299804,Adx
+1343299891,Mahika
+1343300482,Mitosis
+1343300831,Bytes the Shadow
+1343300937,Darkk
+1343301091,Ferah Palacost
+1343301109,Cal's Alch
+1343301111,Palacost Tink
+1343301116,Callaway
+1343302533,Vistar
+1343302534,Darnas
+1343302749,Drink the Salvage
+1343304095,The Fuzz'
+1343305228,Majorscl
+1343305722,Mailia
+1343305829,The Mustaffa
+1343306431,Aetheria
+1343306434,Caulnalain
+1343306436,Count Renari
+1343306447,Frelorn
+1343306453,Quest Timer
+1343306567,Mirko cro cop
+1343307505,Cygmus
+1343308321,Perrin Ayabara
+1343308425,Salvage is heavy
+1343308726,Bronze Wind-up Gearknight
+1343309000,Das Salvage
+1343309124,Wanderlei
+1343309812,Majors Are Heavy
+1343309822,Mauricio 'Shogun' Rua
+1343309900,Babywipe
+1343313261,Elo's Gk
+1343313960,Evil's Gk
+1343314822,Amuli and Celdon
+1343316647,Alex Graham
+1343319479,Ubereem
+1343319857,Mag-newb armor weap
+1343320295,Mag-tinker
+1343320424,Mag-nus
+1343320425,Mag-six
+1343320429,Fquicker
+1343320456,Mag-lite
+1343320459,Mag-five
+1343320491,Mag-seven
+1343320613,Fquick
+1343320614,Mag-Salvager
+1343320724,Elorean
+1343325481,Emme
+1343325482,Shen Do
+1343326097,Mag-z ivory
+1343326098,Mag-z colo rings
+1343326311,Mag-z money
+1343326312,Mag-z comps
+1343326313,Mag-z bling
+1343326314,Mag-z underwear
+1343326315,Mag-z swords
+1343326316,Mag-z wands
+1343326317,Mag-z aetheria
+1343326919,Mag-z Set Adept Wise
+1343326920,Mag-z Set Defender
+1343326921,Mag-z Set Hearty Soldier
+1343326923,Mag-z Set Other
+1343326924,Mag-z Armor
+1343327058,Mag-z foolproof
+1343327542,Mag-z cov salvage
+1343327589,Mag-z alduressa
+1343327632,Mag-z brass
+1343327633,Mag-z green garnet
+1343327634,Mag-z iron
+1343327635,Mag-z granite
+1343327636,Mag-z gc salvage
+1343327637,Mag-z misc salvage
+1343327757,Mag-z steel a
+1343327885,Mag-z alduressa b
+1343328174,Mag-z tenassa
+1343328327,Mag-z steel b
+1343328664,Mag-z leather
+1343328679,Mag-z colo items
+1343328931,The Stoner
+1343330247,Nonami
+1343331256,Ulm
+1343331407,Nester
+1343334574,Shadow Caller
+1343334951,Vain Glory
+1343340465,Colier Mine Second Shift Foreman
+1343340493,Jinto Wex
+1343340495,Celdin
+1343340530,Colier Mine Chef
+1343340645,Sevenofnine
+1343340677,Deceptive Cadence
+1343340733,Colier Granite Quarry
+1343340751,Colier Steel Works
+1343340752,Colier Brass and Metallurgy
+1343341673,Colier Farm Assist
+1343342055,Dad Blaster
+1343342059,Hasselblad
+1343342161,The Guardian of Lost Light
+1343342738,Noble Fir
+1343342739,Grand Fir
+1343342740,Sacred Fir
+1343342741,Giant Fir
+1343342742,White Fir
+1343342744,Corkbark Fir
+1343342750,The Drudge Mule XVII
+1343343113,The Drudge Mule XVIII
+1343343114,The Drudge Mule XIX
+1343343115,The Drudge Mule XX
+1343343117,The Drudge Mule XXI
+1343343118,The Drudge Mule XXII
+1343343120,The Drudge Mule XXIII
+1343343121,The Drudge Mule XXIV
+1343343122,The Drudge Mule XXV
+1343343123,The Drudge Mule XXVI
+1343343124,The Drudge Mule XXVII
+1343343125,The Drudge Mule XXXVII
+1343343126,The Drudge Mule Xlvii
+1343343127,The Drudge Mule Lvii
+1343343128,The Drudge Mule Lxvii
+1343343129,The Drudge Mule XXVIII
+1343343130,The Drudge Mule XXXVIII
+1343343131,The Drudge Mule Xlviii
+1343343132,The Drudge Mule Lviii
+1343343133,The Drudge Mule Lxviii
+1343343134,The Drudge Mule XXIX
+1343343135,The Drudge Mule XXXIX
+1343343136,The Drudge Mule Xlix
+1343343137,The Drudge Mule Lix
+1343343138,The Drudge Mule Lxix
+1343343139,The Drudge Mule XXX
+1343343140,The Drudge Mule Xl
+1343343141,The Drudge Mule L
+1343343142,The Drudge Mule Lx
+1343343143,The Drudge Mule Lxx
+1343343144,The Drudge Mule XXXI
+1343343145,The Drudge Mule Xli
+1343343146,The Drudge Mule Li
+1343343147,The Drudge Mule Lxi
+1343343148,The Drudge Mule Lxxi
+1343343150,The Drudge Mule XXXII
+1343343151,The Drudge Mule Xlii
+1343343152,The Drudge Mule Lii
+1343343153,The Drudge Mule Lxii
+1343343154,The Drudge Mule Lxxii
+1343343155,The Drudge Mule XXXIII
+1343343156,The Drudge Mule Liii
+1343343157,The Drudge Mule Lxiii
+1343343158,The Drudge Mule Xliii
+1343343159,The Drudge Mule Lxxiii
+1343343160,The Drudge Mule XXXIV
+1343343161,The Drudge Mule Xliv
+1343343162,The Drudge Mule Liv
+1343343163,The Drudge Mule Lxiv
+1343343164,The Drudge Mule Lxxiv
+1343343165,The Drudge Mule XXXV
+1343343166,The Drudge Mule Xlv
+1343343167,The Drudge Mule Lv
+1343343168,The Drudge Mule Lxv
+1343343169,The Drudge Mule Lxxv
+1343343170,The Drudge Mule XXXVI
+1343343171,The Drudge Mule Xlvi
+1343343172,The Drudge Mule Lvi
+1343343173,The Drudge Mule Lxvi
+1343343174,The Drudge Mule Lxxvi
+1343343392,House Mulio
+1343343418,House Emulio
+1343343483,Decal Dev Bot
+1343343702,Rand Cadelanne
+1343343703,Lailah Cadelanne
+1343343704,Sorey Cadelanne
+1343343705,Mikleo Cadelanne
+1343343706,Artorias Cadelanne
+1343343720,Mildryth Cadelanne
+1343343738,Heldalf Cadelanne
+1343343740,Tarkus Cadelanne
+1343343741,Aelfwyth Cadelanne
+1343344695,Zhapaj ibn Cadelanne
+1343346493,Cat Devnull
+1343348578,Kaveatta
+1343348989,Colier Librarian
+1343349087,Idshaya al-Xi
+1343349361,Carrion Baggage
+1343349694,Carrion Salvage
+1343350262,Carrion Rares
+1343350414,Carrion Legendary
+1343350477,Carrion Weapons
+1343350748,Ellipses
+1343350751,Asterism
+1343351899,Carrion Legenderriere
+1343353203,Eleaneth
+1343353397,Finessica
+1343354036,Carrion Lugiandary
+1343354417,Mother Mo Fo Mage
+1343354684,Muleington
+1343354693,Xanxin
+1343354700,Havarti
+1343354839,Carrion Klamotten
+1343355219,Salv Armor
+1343355221,Tomrum
+1343355444,Carrion Joules
+1343355505,Kreapist
+1343355584,The Archangel Castiel
+1343355586,The Black Ferah
+1343355667,Colier Contraband
+1343355933,Vote Eps for Mayor
+1343356124,Jean Paul Gaultier
+1343356259,Krigs Magiker
+1343356288,Essence of Beauty
+1343356400,Acidik
+1343356403,Cowhead
+1343356693,Colier Five and Dime
+1343356744,I got small DiTs
+1343356812,Colier Chorizite Refinery
+1343356859,Coded
+1343356984,Eps' Butt Plug
+1343356998,Risen Martine
+1343357048,Aleska
+1343357091,White Guilt
+1343357115,Kinzie
+1343357191,Zero Point Energy
+1343357223,Reinhold
+1343357275,Smeghead
+1343357283,Lil'lug
+1343357334,Little Ben
+1343357381,Newbiess
+1343357382,Stackoverflow
+1343357393,Stackoverflowerror
+1343357402,Right in the Feels
+1343357430,Candeth Menacet
+1343357489,Guld pojken
+1343357500,Ragan the Wanderer
+1343357513,Packets
+1343357525,Yanno
+1343357531,Heavy Night
+1343357542,Pleasantspecter
+1343357547,Kinzie
+1343357551,Kha'ran
+1343357558,Vanarthus
+1343357570,Avita Millman
+1343357580,Heather Downey
+1343357581,Theresa Herrera
+1343357582,Carrie Lynn Vander Ven
+1343357583,Elsie Missen
+1343357584,Elizabeth Bouiss
+1343357585,Isabel Umana
+1343357586,Karen Hjorten
+1343357587,Tana Mattson
+1343357625,Interplanetary
+1343358263,Yoroi Orange Black Gold
+1343358264,Yoroi Red Green Blue Purple
+1343358770,Koji's Beast
+1343359410,Annuwen
+1343359413,Aiobhann
+1343359423,Cymraine
+1343359426,Scatha
+1343360044,Yoroi Blue Purple
+1343367440,Absaroka
+1343368060,Morain
+1343374794,Slaanesh
+1343382061,Luge
+1343382068,Lugey
+1343383606,Vandominus
+1343384495,Legendaries
+1343384587,Solstice of Shade
+1343384844,Soldier's Supplies
+1343384884,Hearty and Dex
+1343384908,Adept and Defender's
+1343385129,Might of the Bow
+1343385133,Blighted
+1343385143,Andrew Carnegie
+1343385444,The Lugian Supplier
+1343385573,Another Storage Lugian
+1343385723,Mule De'Lugian
+1343386099,Jakka
+1343386153,Evil Callaway
+1343386279,Tachikoma
+1343386412,Jak Holden
+1343387060,Jak Heavy
+1343388113,Xaioxian
+1343389473,The name is Bond James Bond
+1343389474,Apple iphone
+1343389476,L M F A O
+1343391956,Leica
+1343393781,Kofi
+1343393782,Khali
+1343395639,Sanux
+1343397387,Marlise
+1343397491,Katherine Maree
+1343397831,Jak Sv
+1343398896,Jak bs
+1343399164,Liqe M'Diqe
+1343399850,Cyberkilla
+1343400110,Emulio Estevez
+1343400216,Emulio Chavez
+1343400227,Emulio Miguel
+1343400256,Emulio Gonzo
+1343400455,Emulio Fernandez
+1343400528,Wallawallabingbang
+1343400896,Bwoon Dub
+1343400897,Funny Little Man
+1343400903,Xepha
+1343400908,Rafinko
+1343400912,High Rule
+1343400920,Ardia
+1343400927,Jobias
+1343400934,Chiefo
+1343400947,Raphouko
+1343400950,Grauda
+1343401646,Harry Hellfire
+1343401883,Kachow
+1343401915,Margulis
+1343401948,Ta Trades
+1343402086,Black Emulio
+1343402091,Senior Emulio
+1343402094,Arkanen
+1343402172,Fuscion
+1343402437,Ta Bowyer
+1343402617,Mulio Miguel
+1343402794,Arco de Velocidad
+1343403194,Jackarse
+1343403281,Valerienpk
+1343403403,Emulio Levar
+1343403699,Ta Mule
+1343403801,Enmos
+1343403831,Irregardless
+1343404337,Emulio Rupert
+1343405624,Suffinmcholdins
+1343405723,Cheezbox
+1343405787,Cheesebox
+1343407228,Ugglymcmulez
+1343407536,Wrecktumologist
+1343408249,Aphira
+1343409552,Deadbobpeaseller
+1343410195,Girlmulei
+1343410198,Margulia
+1343410199,Fuscianna
+1343410201,Skullsberg
+1343410202,Shadowbutt
+1343411785,Quick Storage
+1343413051,Coors III
+1343413463,Amanah
+1343413987,Mediocre Ian
+1343414018,Ian the Intrepid
+1343414166,Lugian Steel
+1343414683,Gottem
+1343414695,Xoatl
+1343415063,Sylvera
+1343415253,Heavyset
+1343415326,Shalukah
+1343415658,Jhoa
+1343415664,Logicoma
+1343415837,Coors Odd and Ends
+1343416666,Aurior
+1343416702,Amanah's Mule
+1343416801,Coors Melee Weapons
+1343416930,Coors Missile Weapons
+1343417554,Cornmealius
+1343417866,Magus the Dark
+1343418124,Algorab
+1343419244,That Running Game
+1343419380,Dirty Storage
+1343420997,Coors Aetheria
+1343422848,Meow'
+1343423573,Underwear
+1343424422,High-Voltage
+1343424790,Silver Creek
+1343425235,Carrying Gold
+1343425406,Creek's Set Pieces
+1343425578,Brambles
+1343425850,Narcotic Reborn
+1343426152,Wilson Wilson
+1343426173,Whatcha Say
+1343426610,Fantastic Bowjob
+1343427748,Coors Rings IV
+1343428168,Deran Dark
+1343429037,Castorio
+1343429130,Daas Boot
+1343430150,Lanellesa
+1343430166,High-Voltage II
+1343430260,Sixty-Four Bit
+1343430275,Squishspielzeug
+1343430971,Crafterella
+1343430981,Muleon De Stuffas
+1343431713,Casterella
+1343431859,Destin
+1343434883,Town Crier's Liar
+1343437582,Coors Consumables
+1343440278,Jon Snow DiEs
+1343445347,Copastetic
+1343455275,High-Voltage's Locksmith
+1343455276,High-Voltage's Locksmith II
+1343455277,High-Voltage's Locksmith III
+1343455279,High-Voltage's Locksmith IV
+1343457995,Veganeesta
+1343457996,Miss Laggy Pants
+1343457999,Hosh Hosh
+1343459924,Zech
+1343460562,Zechron
+1343461877,Simgear Tinker
+1343463329,Wight Blade
+1343464366,Gmo LaBeling Required
+1343464552,Fquick Mule
+1343466570,Svet
+1343467140,Svet mule
+1343467144,Svet-li
+1343467178,Svet-load
+1343467573,Svet-tink
+1343467582,Svet-tinkk
+1343467584,Kseniaa
+1343467587,Sahri
+1343467605,Load-di
+1343467986,Ksen-load
+1343468016,Svet-load-one
+1343468205,Svet-load-letters
+1343468718,Sahri-load
+1343469846,Svet-load-two
+1343470767,Svet-Letters
+1343472814,Soquelo
+1343473847,El Burro Basura
+1343474423,Callaway's Salvage Mule
+1343475270,Soquel's Trade Mule
+1343475791,Helena of Borg
+1343475804,Victor of Borg
+1343479509,High-Voltage's Rare Farmer
+1343483277,Xander'
+1343484099,Miskelan
+1343484229,High-Voltage's Shopping Cart
+1343484283,Justyan
+1343486112,Miyu Rei
+1343486131,Kunari of Lin
+1343487898,Fgsdf
+1343487988,Rob The Hand
+1343488024,Brexit
+1343488764,Kama Koze
+1343489461,Krystira
+1343489517,Mageness
+1343489699,Zech Melee
+1343489702,Zech Tinker
+1343489706,Zech Mule
+1343490247,Vaciante
+1343490411,Ud Tinker
+1343490414,Bremmen
+1343490478,High-Voltage's Rare Farmer II
+1343491008,Zay the Magnificent
+1343491108,We Pwn Khao's
+1343491243,Mule Rox
+1343491246,High-Voltage's Banker II
+1343491247,High-Voltage's Locksmith V
+1343491459,Lootus of Borg
+1343491647,Farmerfran
+1343492054,Dota
+1343492135,Hold DeZ For Me
+1343492494,Mule Rox I
+1343492694,Accepting Donations
+1343492795,Dota II
+1343492818,Starwars
+1343492993,The End is Upon Us
+1343493040,Peace Mezzir-Garrett
+1343493042,Swashbuler
+1343493286,El Snert
+1343493320,Dota III
+1343493337,Pcaping the World
+1343493338,The Dutch Master
+1343493339,The End is Coming
+1343493341,Dota IV
+1343493342,Zarmm
+1343493346,Gabriella Jink
+1343493351,Dota V
+1343493389,Mule Roxii
+1343493390,Mule Rox III
+1343493391,Mule Rox IV
+1343493392,Mule Rox V
+1343493393,Mule Rox VI
+1343493395,Mule Rox VII
+1343493397,Mule Rox VIII
+1343493398,Mule Rox VIIII
+1343493412,Raxem
+1343493428,Hold More
+1343493432,Dark Mazur
+1343493435,Dark Noble Malzar
+1343493436,Dark Malzar
+1343493441,Dota VI
+1343493453,Jak end
+1343493543,Diddly Squat
+1343493571,Dota VII
+1343493601,Liam Neeson
+1343493612,Krystana
+1343493635,Last Breath'
+1343493763,Raistln
+1343493791,Asoph
+1343493796,Dataman-Warmage
+1343493904,Emberlaine
+1343493933,Sklerp
+1343493936,Amanah Dw
+1343493953,Ash Gromnies
+1343493987,Llac Norehsa
+1343494006,Jakthoi
+1343494011,Kiss Me I'm Gay
+1343494013,Testacemu
+1343494019,Surloshen
+1343494020,Dardante
+1343494025,Mosswart Fort Leader
+1343494027,Stackoverflows
+1343494030,Mosswart Fort Conqueror
+1343494083,Free salvage
+1343494089,Shadow Log
+1343494097,I Hide Stuff In My Butt
+1343494098,Heavy Weapon
+1343494099,Missile Weapon
+1343494110,Crithaya
+1343494129,Legendary Armors
+1343494132,Tuoshaixi
+1343494134,Vanarthus
+1343494135,Dskdan
+1343494138,The Olthoi Covenant
+1343494139,Legendary Set Armor
+1343494140,Legendary Rings
+1343494152,Crabbattle
+1343494203,Solitary'
+1343494240,Wb Executive
+1343494241,Severlin'
+1343494267,The End is Here
+1343494308,Sabina Pasic
+1343494309,Jody Smith
+1343494310,Liz Bouiss
+1343494311,Laura Cristina Herrera
+1343494312,Virginia Theresa Herrera
+1343494316,Packetgimp
+1343494337,Undead Camp King
+1343503153,Newbies Wit Attitude
+1343504351,Black Wish
+1343509277,Spotieodiedopalicous
+1343514752,Tidesroar
+1343523896,T'H'E D'A'R'K O'N'E
+1343533150,Gov
+1343535071,Rage of the Darkness
+1343556164,Ash Gromnies
+1343561630,Baeth Elgolhuir'Bulkur
+1343587494,Deebo'
+1343593571,The Dark Decending
+1343597638,Deathsquire
+1343627022,Zero hour
+1343636809,Bremmen of Itb
+1343640451,Maynard James Keenan
+1343640454,Spartan-Atlas
+1343640456,A Blacksmith
+1343664605,Dread Trogdor
+1343670165,Mange Lange
+1343679586,Gagga Maggot
+1343687126,A A
+1343687845,Blood Sky
+1343687877,Salur al-Zaraf
+1343689531,Thomas the Cat
+1343690013,Egorian
+1343695474,Midnight The Dark
+1343695867,Say tan
+1343701764,Real killa
+1343715795,Anoob
+1343716955,Vk-mage
+1343717385,The Unknown'
+1343718571,Koma-xxx
+1343724266,Matrix'
+1343724703,A taste of cahos
+1343724717,A taste of chaos
+1343724834,Carry Dez
+1343725037,Nicca
+1343725554,Teabagged
+1343731748,Addraevan'
+1343731984,Alchy-Mist
+1343736701,Kamikaze Chick
+1343738773,Aastrella
+1343743514,Urahara
+1343777707,Razlam
+1343784593,I Pwn all Noobs
+1343789100,Scuba Smith
+1343789507,Fisherman Steve
+1343790308,The Scuba Squad
+1343790484,Omghealz
+1343803904,Genese
+1343804590,Congo Natty
+1343804678,Under attack
+1343807209,Bag pack Storage
+1343809061,Enemy spoted
+1343810636,Bag Back Storage I
+1343812638,Bag Pack Di
+1343815589,Maxmagicdefense
+1343832053,Ya Dig
+1343836416,Arkaina
+1343837035,Xcxcxcx
+1343837036,Fgfgf
+1343837037,Fdgvcb
+1343837038,Vcbvbcv
+1343837039,Bvnvbnvb
+1343837040,Cvxcvxcvx
+1343837041,Dfgdfgdfcvbcv
+1343837042,Dghfhftg
+1343837043,Zxczxczx
+1343837044,Czxczxcz
+1343837045,Cxzczxcz
+1343838080,Gnostic Mag
+1343846586,Lost Goods
+1343879484,Farfinugen
+1343879488,Shibble Pip McPickle
+1343880489,Baeth Le Farfadet
+1343881666,Genese Dread Wish
+1343881667,Genese dreadagger
+1343881940,Esprit Des Bannis
+1343883940,Crazy Hands
+1343885388,Le Porteur
+1343890284,R and S
+1343890285,Porteur d'Alchemiste
+1343890286,Weap Boy
+1343890287,Armurier
+1343892016,Mr Fz
+1343892344,Le S and R
+1343892602,Psychosomatic
+1343892884,Khapa L'Aztec
+1343893389,Deran Darkness
+1343894174,Drowzee
+1343895202,I Test Portals
+1343895285,Kiss me I'm Gay
+1343902738,House Storage
+1343902964,Woow
+1343903524,Copyright Vk and Co
+1343903527,Swindler Barter
+1343903528,Long Shot n Wands
+1343903529,Short Shot et Melee
+1343903530,L'Imbueur
+1343903582,Weapon Salvager
+1343903583,Armor Salvager
+1343904987,Deva Kali
+1343905155,Aztec Les Indigenes
+1343908343,Aabbcc
+1343909744,Kdjvsdkf
+1343914112,Ultraviolet
+1343915248,Yuygjhjgh
+1343919437,City of Egos
+1343920060,Iusidopasda
+1343921309,Lungbreaker
+1343924020,Graveler
+1343925786,Heijoshin
+1343933821,Marowak
+1343934712,Wielders
+1343937333,Imbuer Weapon Salvager
+1343937524,Shen Do's Treasures
+1343937960,Yougonnadie
+1343947076,Super Metroid
+1343949165,Hold it'
+1343953294,Bigbad
+1343953728,That Really Grinds My Gears
+1343954021,Magma Golem Exarch
+1343961371,Motor Mouth
+1343976740,Salvage Bia
+1343979427,Dsfsdfsf
+1343981330,Dt Assasin'
+1343981333,Ya digs alt
+1343981336,It dont matter
+1343981358,Gayness Maximus
+1343981784,Random Reroll
+1343983421,Phantom's Mule
+1343991339,Vertales
+1343991925,Lissitha
+1343992695,Vegan Cannibal
+1344009669,Whaaaaaa
+1344012948,Fackin Eh
+1344013931,Deuce Dropper
+1344016309,Short Bus Bully
+1344018063,Slug Bug
+1344018920,Gold Mule Bia
+1344019045,First Games of Childhood
+1344019054,Illuminating Void
+1344020363,Asea
+1344020399,Sao sin
+1344020891,Johan Franzen
+1344020911,Trench Coat Flasher
+1344022507,Hat-Trick
+1344023668,Cashmoneyallday
+1344023983,Moose Knuckles
+1344024061,Spank Bank
+1344026664,Shojin-ri
+1344027092,Beholdened
+1344027650,Cimerrrra
+1344028861,Kilaeioaf
+1344029443,Holdertt
+1344029550,Table
+1344032535,Selig
+1344032604,Owain
+1344032741,Olthoi Nobel
+1344032895,Kugos
+1344032969,Loddy
+1344036378,Srfgjsgjsryj
+1344036687,Hfjfghfgh
+1344036931,L'Ancien
+1344038118,Ogrok Soul Bender
+1344043043,Atlan Vahn Lunatic
+1344047889,Prepare Your Anus
+1344048207,Cheezbox
+1344048462,Muleguy I
+1344058711,Akal of the White Sands
+1344058954,Ill Profit
+1344058965,Breh
+1344058966,Lowki
+1344062633,Spirit person
+1344064847,Bloodtaster
+1344065414,La P'tite Flectchy
+1344067096,Sniksnork
+1344067099,Clisp
+1344072009,Violet Rain
+1344075614,Bowman Josephus
+1344077134,Big Lenny
+1344077141,Senor Chang
+1344077470,Ujiio
+1344081116,Bow of the Ancients
+1344081612,Kyyuzo
+1344085682,Hyjetyujtryjtryjrtyj
+1344111524,Pat p
+1344112350,Mark g
+1344112405,Worthington Foulfellow
+1344113248,Steve r
+1344116032,Russel o
+1344116523,Greg a
+1344125611,Phantom Sight
+1344137645,Art f
+1344148781,Meat Man Joe
+1344149639,Arwens
+1344149640,Bilbao
+1344149641,Cirano
+1344149642,Devos
+1344149643,Erwans
+1344149644,Fernandez
+1344149645,Guilerm
+1344149646,Herwans
+1344149647,Iszin
+1344149648,Jerloo
+1344149649,Keeboots
+1344151091,Ashly g
+1344151320,Milosa
+1344151330,Little person
+1344153705,Hulkster
+1344154915,Chad p
+1344156931,Sssaaalllvvvaaagggeee
+1344157996,Fdsfadsa
+1344161788,Imtrippin
+1344162601,El fedor
+1344162603,Kellyclarkson
+1344162604,Tinkmebaby
+1344162605,Taylorswift
+1344162606,Loubega
+1344163850,Blackjack Davey
+1344165297,Dumppp Offf Mule
+1344165329,Untinked Rare Death Items
+1344165449,Rare wand dis
+1344165552,Noob Night
+1344165568,Sallllllllllllllvage
+1344167606,Brass Me Life
+1344171851,Pull the Dicks out
+1344172022,I Carry On
+1344172046,Le Porteur d'Armures
+1344172074,Brokkr
+1344172147,Bone Dealer
+1344172148,Bone Supremacy
+1344172149,Bone Dreamer
+1344172491,Sindrii
+1344172632,Inti
+1344174358,Hlin
+1344174825,Gorzak
+1344174908,Dark Mazur
+1344174909,Raxem
+1344174910,Phare Well
+1344174931,Noob God
+1344174935,Rip Best Game Ever
+1344174949,Crabbattle
+1344174975,Killerwolf III
+1344174987,Grombly
+1344175005,Ripley of Frostfell
+1344175012,Zojak Quazith
+1344175017,Sloppy Giuseppe
+1344175034,Org of the Hill People
+1344175045,Blood Quench
+1344175055,Beep Beep Boop
+1344175059,Sloppy Giuseppe's Secret Sausage
+1344175062,Shorty the Eternal'
+1344175085,Zap Pa
+1344175102,Bodhisattva of the Sword
+1344175125,Lightfighter
+1344175138,Whoopsie Goldbug
+1344175155,Stunky Turdington
+1344175158,Luurch
+1344175164,Killerwolf II
+1344175170,Defeated defeated defeated
+1344175180,Olthoi Fuccboi
+1344175187,Killerwolf IV
+1344175197,Jakthoi
+1344175210,Dagryn Stabir
+1344175277,Theresa Herrera
+1344175292,Bhagevad Gita
+1344175293,Billy Herrington
+1344175294,Billy Herrington
+1344175305,Big D Boy
+1344175314,Faelicity
+1344175337,Bladeslinger'
+1344175340,Van Darkholme
+1344175354,Www Acemulator Org
+1344175389,Emulator In Progress
+1344175395,Anoobeer
+1344175396,Emulators
+1344175397,Charlie Murphy III
+1344175400,Your Mother II
+1344175401,Olthoirgreat
+1344175417,Droden Is A Giant Tawat
+1344175460,Malthus Thayer
+1344175465,Angie Kreynus
+1344175466,Isabel Umana
+1344175467,Crisinta Herrera
+1344175468,Heather Downey
+1344175469,Lisa Grace Cole
+1344175470,Elizabeth Bouiss
+1344175471,Jody Smith
+1344175472,Yasha Carpentier
+1344175473,Christina Herrera

--- a/aclogview/Form1.Designer.cs
+++ b/aclogview/Form1.Designer.cs
@@ -393,7 +393,7 @@ namespace aclogview {
             this.copyTextMenuItem,
             this.copyHexMenuItem});
             this.hexContextMenu.Name = "hexContextMenu";
-            this.hexContextMenu.Size = new System.Drawing.Size(214, 48);
+            this.hexContextMenu.Size = new System.Drawing.Size(215, 48);
             this.hexContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.hexContextMenu_Opening);
             this.hexContextMenu.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.hexContextMenu_ItemClicked);
             // 
@@ -401,7 +401,7 @@ namespace aclogview {
             // 
             this.copyTextMenuItem.Name = "copyTextMenuItem";
             this.copyTextMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyTextMenuItem.Size = new System.Drawing.Size(213, 22);
+            this.copyTextMenuItem.Size = new System.Drawing.Size(214, 22);
             this.copyTextMenuItem.Text = "Copy as &Text";
             // 
             // copyHexMenuItem
@@ -409,7 +409,7 @@ namespace aclogview {
             this.copyHexMenuItem.Name = "copyHexMenuItem";
             this.copyHexMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.C)));
-            this.copyHexMenuItem.Size = new System.Drawing.Size(213, 22);
+            this.copyHexMenuItem.Size = new System.Drawing.Size(214, 22);
             this.copyHexMenuItem.Text = "Copy as &Hex";
             // 
             // tabProtocolDocs

--- a/aclogview/Form1.Designer.cs
+++ b/aclogview/Form1.Designer.cs
@@ -119,6 +119,7 @@ namespace aclogview {
             this.queueMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.iterationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.serverPortMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuItem5 = new System.Windows.Forms.MenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer_Main)).BeginInit();
             this.splitContainer_Main.Panel1.SuspendLayout();
             this.splitContainer_Main.Panel2.SuspendLayout();
@@ -625,6 +626,7 @@ namespace aclogview {
             this.mnuItem_ToolFindOpcodeInFiles,
             this.menuItem_ToolFindTextInFiles,
             this.menuItem_ToolPcapScraper,
+            this.menuItem5,
             this.menuItem2,
             this.menuItem_ToolBad,
             this.mnuItem_ToolFragDatListTool,
@@ -652,29 +654,29 @@ namespace aclogview {
             // 
             // menuItem2
             // 
-            this.menuItem2.Index = 3;
+            this.menuItem2.Index = 4;
             this.menuItem2.Text = "-";
             // 
             // menuItem_ToolBad
             // 
-            this.menuItem_ToolBad.Index = 4;
+            this.menuItem_ToolBad.Index = 5;
             this.menuItem_ToolBad.Text = "Find Bad Parsers";
             this.menuItem_ToolBad.Click += new System.EventHandler(this.menuItem_ToolBad_Click);
             // 
             // mnuItem_ToolFragDatListTool
             // 
-            this.mnuItem_ToolFragDatListTool.Index = 5;
+            this.mnuItem_ToolFragDatListTool.Index = 6;
             this.mnuItem_ToolFragDatListTool.Text = "Frag Dat List Tool";
             this.mnuItem_ToolFragDatListTool.Click += new System.EventHandler(this.menuItem_ToolFragDatListTool_Click);
             // 
             // menuItem4
             // 
-            this.menuItem4.Index = 6;
+            this.menuItem4.Index = 7;
             this.menuItem4.Text = "-";
             // 
             // menuItem_Options
             // 
-            this.menuItem_Options.Index = 7;
+            this.menuItem_Options.Index = 8;
             this.menuItem_Options.Text = "Options";
             this.menuItem_Options.Click += new System.EventHandler(this.menuItem_Options_Click);
             // 
@@ -976,6 +978,12 @@ namespace aclogview {
             this.serverPortMenuItem.Size = new System.Drawing.Size(131, 22);
             this.serverPortMenuItem.Text = "Server Port";
             // 
+            // menuItem5
+            // 
+            this.menuItem5.Index = 3;
+            this.menuItem5.Text = "Combat Scraper";
+            this.menuItem5.Click += new System.EventHandler(this.menuItem5_Click);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1127,6 +1135,7 @@ namespace aclogview {
         private System.Windows.Forms.ToolStripMenuItem iterationMenuItem;
         private System.Windows.Forms.ToolStripMenuItem serverPortMenuItem;
         private System.Windows.Forms.MenuItem menuItem_ToolPcapScraper;
+        private System.Windows.Forms.MenuItem menuItem5;
     }
 }
 

--- a/aclogview/Form1.cs
+++ b/aclogview/Form1.cs
@@ -1665,6 +1665,12 @@ namespace aclogview
                 objectsContextMenu.Show(location);
             }
         }
+
+        private void menuItem5_Click(object sender, EventArgs e)
+        {
+            var form = new CombatScraper();
+            form.Show(this);
+        }
     }
 }
 

--- a/aclogview/Form1.resx
+++ b/aclogview/Form1.resx
@@ -117,11 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="hexContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>671, 18</value>
-  </metadata>
   <metadata name="parsedContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>358, 17</value>
+  </metadata>
+  <metadata name="hexContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>671, 18</value>
   </metadata>
   <metadata name="listviewContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>816, 18</value>

--- a/aclogview/Lists/CharacterList.txt
+++ b/aclogview/Lists/CharacterList.txt
@@ -1,0 +1,2933 @@
+1342178494,Azrakin
+1342179198,Cyberkiller
+1342181083,Baal
+1342181790,Fenn
+1342181842,Haji
+1342183662,Eichschet
+1342183844,The Anarchs
+1342188059,Kodiak
+1342191277,Mjollnir
+1342191312,Ice Eyes
+1342191318,Chief Wifebeater
+1342202025,Lai-Lynn
+1342202659,Crash
+1342212533,Jack Handyman
+1342212536,Bow Duke
+1342217300,Kirk of Rithwic
+1342218320,Dural
+1342219201,Dr Doom
+1342220523,Turok
+1342223697,Dwynna
+1342224097,Willoughby Spit
+1342233731,Kurse
+1342236569,Goblin
+1342239538,Fizbee
+1342241043,Maid of the Blade
+1342241366,Li'l Prob
+1342243275,Vasquaz the Archer
+1342244425,Ashahel
+1342245630,Dave was here
+1342246485,Pack man
+1342249174,Reign of the Crow
+1342251187,Killerwolf
+1342254282,Lt Ripley
+1342254297,Ripley the Mage
+1342256546,Hex
+1342257025,Disease
+1342259520,Heero-Yuy
+1342263323,Ssttaassttaa
+1342264661,Spectre
+1342269877,Jesse the Knight
+1342270612,Beast
+1342271037,Stabby Stabberstein
+1342271044,Pack Ma'am
+1342279213,Nozokai
+1342283587,Rajja
+1342295192,Nozo Kai
+1342299258,Hy's Stuff Holder
+1342300036,Devil's Blade
+1342305246,Mana Man II
+1342306713,Strider Longshanks
+1342309424,Faramyr
+1342320305,Doctor Evil
+1342321228,Elzy
+1342331244,Aikido
+1342335084,Branor
+1342335085,Faramyr
+1342335768,Prism
+1342336414,Temppy
+1342336547,Testinga
+1342337386,Ghar
+1342340464,Kildor
+1342340997,Jarrod Li
+1342347497,Cyndra
+1342353070,Evincar
+1342353787,Glorix
+1342360844,Stormcloud
+1342366526,Dez'Mron Treasurer
+1342368999,Scuba Steve
+1342371327,Ninwa Chang
+1342372383,Cowhead
+1342377334,Ogg Cave-Man
+1342378857,Cricket
+1342380067,Dural Wadesun
+1342382130,Cowhead's other mule
+1342383108,Hop Singh
+1342383542,Shakalakka
+1342391394,Mag-tinker
+1342391395,Mag-one
+1342391396,Mag-two
+1342391397,Mag-three
+1342391398,Mag-four
+1342391399,Mag-five
+1342391400,Mag-six
+1342391402,Mag-eight
+1342391403,Mag-nine
+1342391404,Mag-seven
+1342391462,Mag-z newb armor
+1342391503,Mag-z brass
+1342391504,Mag-z brass b
+1342391506,Mag-z steel
+1342391507,Mag-z steel b
+1342391508,Mag-z ivory
+1342391510,Mag-z imbue
+1342391511,Mag-z money
+1342391512,Mag-z temp
+1342391535,Mag-z granite
+1342391560,Mag-z steel c
+1342391561,Mag-z green garnet
+1342391631,Mag-z granite b
+1342391632,Mag-z imbue b
+1342391706,Mag-z temp b
+1342391707,Mag-z imbue gc
+1342391749,Mag-z green garnet b
+1342391772,Mag-z iron
+1342391773,Mag-z temp c
+1342391946,Mag-z iron b
+1342391955,Mag-z cov salvage
+1342392016,Mag-z newb weapons
+1342392081,Mag-z colo rings
+1342392153,Mag-z foolproof
+1342392432,Mag-z set adept
+1342392433,Mag-z set wise
+1342392434,Mag-z set hearty
+1342392435,Mag-z set defender
+1342392436,Mag-z epic armor
+1342392470,Mag-z twohands
+1342392472,Mag-z bows
+1342392508,Mag-z wands
+1342392509,Mag-z colo items
+1342392932,Mag-z trinkets
+1342392934,Mag-z bling b
+1342392935,Mag-z bling
+1342392936,Mag-z underwear b
+1342392937,Mag-z underwear
+1342393030,Mag-z leather
+1342393074,Mag-z colo rings b
+1342393075,Mag-z foolproof b
+1342393360,Mag-z old wands
+1342393763,Mag-z colo items b
+1342394545,Mag-z aetheria b
+1342394546,Mag-z aetheria r
+1342394547,Mag-z aetheria y
+1342394548,Mag-z cloaks
+1342394549,Mag-z imbue bling
+1342394550,Mag-z quest equip
+1342394789,Mag-z heavy
+1342394790,Mag-z light
+1342394791,Mag-z finesse
+1342395395,Mag-z rares
+1342395920,Mag-z heavy dagger
+1342395921,Mag-z heavy axe
+1342396876,Mag-z trinkets b
+1342397598,Mag-z spell comps
+1342398676,Mag-z tinker equip
+1342399728,Mag-z master
+1342401215,Callaway
+1342401215,Keoki Al-Maya
+1342401317,Mag-z dual legendaries
+1342403957,Mag-z rings
+1342404309,Mag-z money b
+1342405117,Mag-z bling c
+1342405118,Mag-z underwear c
+1342407446,Kira Sahoto
+1342409493,Xxxxx
+1342410155,Mooolie
+1342410232,Moolie
+1342410235,Moolfasa
+1342410388,Killerwolf
+1342410443,Chesty
+1342410606,Brambles
+1342410611,Snarg
+1342410652,Pom Pom
+1342410712,Grael
+1342410726,Moom
+1342410852,Hip
+1342410903,Holden Grease
+1342410990,Moving Company
+1342411002,Biggle
+1342411004,Triumph
+1342411167,Compy
+1342411187,Bridge Hermit
+1342411252,Snoo Snoo
+1342411621,Bromeliad
+1342411636,Rhonda
+1342411916,Cycad
+1342411962,Borage
+1342412026,Heliotrope
+1342412155,Tumnus
+1342412442,Miss Rumphius
+1342412628,Aquilegia
+1342412763,Take It
+1342412896,Pansy
+1342412897,Petaluma
+1342414600,Hell's Care Taker
+1342415063,Hakim al-Wanganator
+1342415682,Soul Stealer
+1342417572,Dwynna Wildshot
+1342423309,Keoki's Alchemist
+1342423741,Stargren Dragoon
+1342424857,Ogg's Main Mule Man
+1342425734,Manala al-Cabul
+1342426987,Aziz al-Jamal
+1342432869,Ashahell
+1342433482,Mag-z temp d
+1342434441,Mag-z cloaks b
+1342435121,Jynnx
+1342435553,Mag-z set dex
+1342435554,Mag-z set wise b
+1342435555,Mag-z set adept b
+1342435556,Mag-z set defender b
+1342435558,Mag-z bows b
+1342435852,Mag-z set hearty b
+1342435853,Mag-z pets
+1342436303,Sun-Lynn
+1342436702,I Help Cowhead
+1342436792,Exopaladin
+1342436799,Asdfasdfasdfasd
+1342436801,Lisa Grace Cole
+1342436802,Carrie Lynn VanDerven
+1342436803,Llllllllllllllllllll
+1342436806,Adsfasdfasdf
+1342436807,Asdfasdffafas
+1342436808,Afafafafafaf
+1342436809,Aassfafafasd
+1342436810,Asdfasdfasdfaa
+1342436812,Chelsea Case
+1342436813,Cristina Herrera
+1342436814,Karen Hjorten
+1342436815,Jody Smith
+1342436816,Isabel Umana
+1342436817,Kara Finch
+1342436818,Aaaabbbaaaba
+1342441436,Vivi-Orunitia
+1342442959,Slim the shaddy
+1342444898,Heero-Yuy
+1342446206,Red Fox
+1342446708,Kryptic
+1342447549,Soulless
+1342450668,Nostromo
+1342453501,Ssgonts
+1342453869,Branith
+1342460458,Heero-Yuys Mule
+1342461129,Yo ho ho
+1342463381,Bouji-Bouji
+1342465241,Lisa G
+1342469935,Inferno Of Death
+1342471512,Eichy
+1342478451,Gohe the Swift
+1342479658,Minaris
+1342480205,Oykib
+1342489183,Doris
+1342489648,Striderlongshanks
+1342501904,Evincar's Mule
+1342503241,Lil One
+1342506535,Big Black Mofo
+1342507060,Lauralise
+1342510072,Logan Darkstar
+1342512050,Eternal Spirit
+1342514224,Gryphon
+1342514441,Fluffy Bunny
+1342515946,Herrin
+1342515957,Jini Starburst
+1342517980,Egbert
+1342518978,Contra
+1342519067,Gryp
+1342520737,Lauralise
+1342522845,Halvard the Red
+1342524532,Red Rose
+1342525162,Sushi Maru
+1342526335,Mithril
+1342528504,Zoishe
+1342530658,Frostwind III
+1342531172,Ampeg
+1342531669,Faramyr
+1342534114,Death Tard
+1342536154,Archimedies
+1342538117,Prey
+1342539271,Tenzo Yoshihara
+1342539979,Kricket
+1342540280,Flayh Mule
+1342540334,Admon Faye
+1342540436,Mind Riot
+1342543765,Ampeg Mule
+1342545132,Ferahgo's mule
+1342545824,Ferahgo the assasin
+1342546743,Gandalf Grey
+1342547755,Brother Trevor
+1342556511,Juliana Bravehart
+1342557104,Kara Sue
+1342557106,Lisa Grace
+1342557107,Carrie Lynn
+1342557108,Theressa
+1342558511,Emulio
+1342560526,Stargren III
+1342560837,Yo Yo Yo Yo
+1342563021,Arkai
+1342566338,D'hm Bulb
+1342568316,Oykib's Alchemist
+1342569462,Shackleton
+1342569516,Yasmina al-Shamir
+1342571072,Squire Juliana
+1342572259,Dracon
+1342572265,Blade
+1342572923,Quick
+1342573782,X-force
+1342574254,Iodized Salt
+1342574622,Wahooka the Great
+1342579287,Malchir
+1342585330,Frost's Alchemist
+1342585674,Seagryn
+1342589188,Jesse the Destroyer
+1342595263,Ulfang
+1342596079,Ridley
+1342598908,Fizz Two
+1342598918,Heero-Yuy's Slaveman
+1342602465,Zombi
+1342602652,Notsher
+1342602660,Lemmeno
+1342602663,Nokando
+1342603100,Cow The Cooker
+1342604862,Kryx
+1342605192,Pugilatrix
+1342606709,Roxx
+1342607014,Kritical
+1342608822,Asa
+1342611298,Corran Li
+1342612287,Ragarnok
+1342612303,Nova Weapon
+1342614110,Declan al-Maya
+1342615087,Haga
+1342617715,Lil Prob
+1342620145,Heero-yuy II
+1342620788,Bossman the Big
+1342620788,Dakkon Blackblade
+1342621913,Neds Atomic Dustbin
+1342621946,Vernish
+1342623123,Osis
+1342624423,Lisa Grace
+1342624425,John David
+1342624426,Lisa Grace Cole
+1342624552,Eichy III
+1342624774,Eichy IV
+1342624938,Eichy VI
+1342624939,Eichy VII
+1342630936,Faramyr
+1342632215,Kamikaze Kid
+1342632973,Gw the Swiftkiller
+1342634396,Funktacular
+1342635000,Ogg Jr
+1342637352,Gibsun II
+1342637872,Fegis
+1342638361,Scwarlock
+1342638730,Johnny d
+1342638781,Ken johnson
+1342638782,Kara sue
+1342638783,Ian fisher
+1342640550,Lisa grace
+1342640551,Johnny d
+1342640552,Carrie lynn
+1342640553,Kara sue
+1342640554,Lisa grace cole
+1342641129,Scwarlocks mule
+1342641273,Dark'Magic
+1342642440,Interim Mad Axe
+1342644320,Yakana
+1342644518,Stargren
+1342648243,E
+1342648334,Fizzle Brokenwand
+1342649582,Aralcarin
+1342651263,Scwarlocks muleii
+1342652882,Deadbolt
+1342652883,Al Mule
+1342653595,Ex-Sent Ripley
+1342655186,Lisa grace
+1342660171,Notsher
+1342660462,Evil Magestic
+1342660984,Battle Mage
+1342661452,Cow's Mule
+1342663469,Keiran Li
+1342663805,Jungle Souljah
+1342665051,Scwarlock's muleiii
+1342665480,Stargren Part Deux
+1342666387,Slims new guy
+1342666779,Dieter the Black
+1342669184,Dwynna
+1342671933,Chef's Salty Chocolat
+1342677529,Mr Mix-It
+1342678173,Darunia the Slayer
+1342682357,Pahd mod Pahd-el
+1342683632,The Fallen
+1342685130,Ingmar
+1342688763,Veylow
+1342689120,Ninavie
+1342691093,Cuddly Rabbit
+1342692275,Shadow Avatar XV
+1342692375,Plush Tusker
+1342694204,Synder
+1342696477,Arie
+1342696490,Killarwolf
+1342700863,Ho Be-Min
+1342703700,Random Chaos
+1342704908,Fibromyalgia
+1342705221,Straharik
+1342705750,Ho Be-Min's Runner
+1342709435,Ho Lin
+1342713146,Test Dt'gharubow
+1342713149,Test Dt'shosword
+1342713155,Test Dt'gharumule
+1342714974,Dave's not here
+1342715686,Frostwind
+1342716353,Miss Fizzel
+1342718597,Scout Drone Mk II
+1342719395,Miab Urro
+1342719929,Kilzeer
+1342720005,The Dreamer
+1342720060,Klatu Verata Nicktoo
+1342720107,The Woodsman
+1342723059,P S Y C H O
+1342725843,Sidhartho
+1342726055,Ua masterman
+1342727958,Fat slim I
+1342728486,Khandra al-Arrr
+1342728503,Keoki's Tinkerer
+1342736276,Chi'En Ching Lung
+1342739298,Acadia
+1342740547,Khandra
+1342740687,White Flare
+1342741106,Rusk
+1342743250,Koko Pele
+1342746788,Kozma
+1342749113,Stargren II
+1342749115,Stargren III
+1342749236,Stargren IV
+1342749238,Stargren
+1342750361,Miach
+1342753073,Immortalbob
+1342754798,Kumalo
+1342754882,D I S T U R B E D
+1342755441,The Mustafa
+1342759686,Bossman's Skillster
+1342760115,Cygmus
+1342766320,Saro
+1342770336,Rylyn
+1342771394,Zedura
+1342771512,Tropica
+1342772034,Carbuncle
+1342772519,Phantom Sight
+1342772582,Scrappy Dooo
+1342772585,Mr Lagg
+1342772587,Hippie the Treehugger
+1342772590,Mullet Master II
+1342772591,Charles Barkley
+1342774393,Josh the Destroyer
+1342774999,Lycentia
+1342777376,Quick Silver
+1342777524,Ikon Blade
+1342781240,Xedura
+1342781304,Antaios
+1342782773,Shady Mule
+1342783025,Velveteen Olthoi
+1342784398,Kreapist
+1342785829,Evil's lil Si Chest
+1342788162,Elluwak Meteu
+1342791712,Kryst al'meth
+1342793037,El Perro Caliente
+1342794612,Whatcha want
+1342795556,Genacide
+1342795845,Crog
+1342796353,Draco Malthoi
+1342796731,Magus the Dark
+1342796855,Oblivious
+1342797132,Eich
+1342799533,Dark Corsair
+1342799809,Saori
+1342799932,Railstan
+1342801896,Frazteak
+1342802120,Taisara
+1342802127,Erroneous
+1342806659,Bascule
+1342807732,Deathspawner
+1342808663,Phoxshot
+1342811053,Heeromuleii
+1342811819,American Zero
+1342813192,Ayza
+1342814022,Mozart's Requiem
+1342814975,Ripley
+1342815056,Arrow of the Dark
+1342816094,Syclones
+1342816952,Mixme
+1342816977,Ekime
+1342818999,Awullsu Quenisquney
+1342819610,Darkshot Dragoon
+1342820976,Faramyr
+1342820995,Zarkard
+1342822780,Nineveh
+1342824599,Pops
+1342825126,Gandalf the Pink
+1342825128,White Charles Barkley
+1342825789,Narcotic
+1342826002,Galaxian
+1342826683,Chatlin
+1342829312,Poison the Well
+1342829958,Ulala
+1342831260,Tylane
+1342831552,Ultramega
+1342832939,M U L E
+1342833174,Galadrim
+1342833187,Killerwolf one
+1342833188,Killerwolf two
+1342833189,Killerwolf three
+1342833194,Killerwolf five
+1342833195,Killerwolf four
+1342834542,Pick-it
+1342834610,Sammet
+1342836288,Admon's Peace
+1342836837,Oh Gee Mage
+1342837194,Required Input
+1342838598,Imhotep Amun-Ra
+1342840224,Takamine
+1342840299,Junias Bravehart
+1342841935,Dtassassin
+1342842474,Max Illidge
+1342842529,Ary'anna
+1342842583,Chaos Reigns
+1342842584,Supreme Chaos
+1342842586,Conflict of Interest
+1342842588,Triple Ex
+1342843153,Nod the Mule
+1342846062,O-Ren Ishii
+1342848644,Fugginay
+1342848769,Bow Duke
+1342852089,Uncle P
+1342852592,Esvectus
+1342852963,Teufel-Magie
+1342853657,Ignignokt
+1342853948,Junyper
+1342855203,Granis
+1342857570,Jina
+1342864128,Yangnom
+1342866589,Aliah the radiant
+1342866589,Bubble Boy II
+1342867234,Four Fifty Four
+1342869783,Black Bunnay
+1342870851,Dirty Dee
+1342871959,Taurin
+1342872038,Aerfalle's Mom
+1342872687,Xcar
+1342872887,Big Al Ho
+1342873181,Ahlindra
+1342873741,Gyer
+1342874164,Quarantine
+1342874166,Fighter of Foo
+1342875091,Twisted Tinkerer
+1342875157,The Bowsman
+1342875353,Coors Light Man
+1342875531,Coors Light Woman
+1342875770,Wilcot the Butler
+1342875837,Grady
+1342876084,Jsuy
+1342876115,Magic Man
+1342876342,Victor von Doom
+1342876527,Phoxsord
+1342877009,Cookies 'n' Cream
+1342877990,Ragarnok
+1342878222,Adair
+1342882415,Narkotik
+1342883383,Yi-like misue
+1342883657,Gfvkvkhb
+1342884364,Dave Dude
+1342884371,Heavy Set
+1342884844,I Don't Like Your Face
+1342889477,Kin Tama
+1342889789,Nadine
+1342891187,Eichy's Trade
+1342891511,Aliah mule
+1342892549,Alexisa
+1342893610,Eugene Levy
+1342894293,Cymry
+1342896022,X Killer
+1342896694,Tink al Ekim
+1342898221,John Bigboote
+1342898453,Jagermech
+1342898870,Deadly Chiapet
+1342900125,Tink R Belle
+1342900582,Sinarg
+1342900793,I Tink I Can
+1342904390,Rush Limbaugh
+1342904864,Wei lo-Down
+1342905929,Cyan Garamonde
+1342906283,Principal Blackman
+1342907840,Branor
+1342909078,Karn Aje
+1342909158,Torath Litson
+1342909951,Hei Shui
+1342909952,Jack The Swift
+1342910593,Test Noob II
+1342910595,Hanz Muleman
+1342910596,Hanz Muleman II
+1342910597,Hanz Muleman III
+1342910793,Test Noob
+1342911189,Mage of Bob
+1342911958,Chien Chaud
+1342912808,Iosep
+1342912993,Jerlan
+1342912994,Jerlana
+1342913379,Porcelina
+1342913953,Genacide X
+1342914023,Jack Litson
+1342916088,Mule Of Bob III
+1342916236,Turak
+1342916262,Tinker Bill
+1342917550,Abiathar
+1342917628,Stride
+1342917975,Phileas Fogg
+1342918388,Chueh Anne
+1342919958,Ryochu Xao
+1342920632,Yves
+1342920667,Whitworth
+1342920895,M U L E II
+1342921456,Meginjarder III
+1342921671,Dark Corsair
+1342921688,Meginjarder II
+1342921736,Snot Grumble
+1342922427,White Bunnay
+1342922536,Salvage holder
+1342924056,Io bhroigbha sdl hnfgaf
+1342924058,The Purple Monkeys
+1342924060,The Magic Nanners
+1342924061,L'l'l'l'l'l'l'l'l'l'l'l'l'l'l'
+1342924096,Vey
+1342924337,Flame Flame the Flame
+1342925278,Fat slim the bower
+1342925507,Idraea
+1342926489,John Malkovich
+1342929458,Enmos
+1342929536,Kwak
+1342929567,Delune
+1342929685,Cartoon Network
+1342929688,Rampart
+1342931421,Super Duper Quinn
+1342931482,Kurse
+1342932644,Born Supremacy
+1342934822,De Icer
+1342937102,Shootin' Blanks
+1342937104,Scoth
+1342937106,Clubbin
+1342937119,Walmart Salvage Department
+1342937237,Precious Metals
+1342937247,Kmart Salvage Department
+1342938221,Makosa'
+1342939433,Mariana K Dasher
+1342939671,Nozo's Mule
+1342939676,Hagreth
+1342940194,Phlogiston
+1342940403,Tristan the Fair
+1342940568,Guardian Mages
+1342941534,Mr Crossbow
+1342944400,Ogg Caveman
+1342944497,Krazy Karl
+1342946741,Deathreaper
+1342946813,Bob the Addlepated
+1342947020,Uzik of Crimson Stars
+1342949155,Huked on Fahniks
+1342949634,Dream Caster
+1342952913,Micke
+1342952954,Devssuxthisgameis Fu
+1342954705,Caffeine
+1342954707,Caffeine's Mule
+1342955124,Stuff Al-Maker
+1342955938,Atonement
+1342956138,Shoui
+1342957800,Immortal Spirit
+1342957988,Lost Kitten
+1342958009,L O C K P I C K A
+1342958272,Blackmoon
+1342959001,Platinum Chef
+1342961715,Stargren V
+1342961724,Meginjarder
+1342962342,Ibecookin
+1342962535,Scrollawlz
+1342963626,Tzhar
+1342964552,Esruk
+1342968837,Verdreht
+1342969165,Adx
+1342969633,Chic mule
+1342969636,Fizzle Brokenwand
+1342970134,Two Hand Luke
+1342970425,Keino
+1342970832,Bascule's Butler
+1342970935,Nemik
+1342970965,Etheldreda
+1342970975,Shattered Visions
+1342971122,Broken Halo
+1342971278,O-o
+1342971364,Egberta
+1342971437,Dwynna Wildshot
+1342971480,Ded En Side
+1342972053,Gyer
+1342972125,Camomille
+1342972566,Brittany'
+1342972763,Blood Loather
+1342972863,Devina
+1342973881,Nostradaemus
+1342974009,Darkmage O' Magic
+1342974570,Anonymous Alcoholic
+1342974918,Salvage
+1342975123,Little Lovebird
+1342975195,Amidala
+1342975486,Main Spring
+1342975508,Thor's Portal
+1342979021,Margulis
+1342979033,Pokn I Out
+1342979876,Pontus
+1342979993,Broccoli Wonderdog
+1342981728,Zanril
+1342982964,Sarak Vol Slim
+1342983131,Dodis
+1342983383,Rapt
+1342983393,Salvage Shop
+1342983694,Plumpy
+1342984971,Immortalbob II
+1342985111,Juliana Bravehart
+1342986019,Flagg'
+1342988711,Mishie
+1342989891,Royal Weapons
+1342990011,Nedless
+1342991008,Naimi
+1342992102,The Keeper of Scrolls
+1342992105,I keep the scrolls
+1342993488,Miach Raider
+1342993568,Luciferia
+1342993737,Sofia
+1342993977,Gundammule
+1342994005,Bearic Dondarion
+1342994006,Bluebetty
+1342994007,Chi-Lee Two
+1342994008,Hectorem Mortem
+1342994009,Biannca
+1342994010,Beyatrice
+1342995557,Acidic
+1342995863,Mosswart Enforcer
+1342996201,Beale
+1342996216,Ball-Dizzle
+1342997067,Beale II
+1342997549,Vandelai Silva
+1342998465,Geartooth
+1342998513,Chief Wifebeater
+1343000072,Spartan Atlas
+1343000213,Kricket's Poolboy
+1343000500,Danee
+1343000683,Ztg
+1343001104,Beale IV
+1343003010,Mulekime
+1343003043,Mulekime III
+1343003235,Zeeiholdcrap
+1343003385,Tradesman Miach
+1343003682,Punk N Drublic
+1343003700,Beale V
+1343004259,Mr Smile
+1343004266,Zeeee Armor Mule
+1343004579,Beale VI
+1343004603,The Internet
+1343004871,Im backing poo cakes
+1343004985,Mirrdin
+1343005230,Delubear
+1343005358,Khandra
+1343005364,Carry Bot
+1343005385,Sumik
+1343005434,Elcia
+1343005478,Mother mo fo mage
+1343005589,Ferio
+1343006049,Criminal Doge
+1343006169,Lunar Space Wizard
+1343006203,Diothe
+1343007554,Impeller
+1343007556,Mason's Salvage Mule
+1343007557,Mason's Armor Mule
+1343007559,Mason the Impaler
+1343007612,Mason's Deadeye
+1343007644,Psycho Slash
+1343007764,Ballz of Steel
+1343007843,Murdoch
+1343007941,Salvage Overflow
+1343008545,Fail Dye
+1343008928,Zee Di Holder
+1343009046,Yumioni
+1343009054,Yumichi
+1343009119,Mind the Void
+1343009120,Bombardment
+1343009121,Restitute
+1343009306,Hold my Sack
+1343010040,Average Square
+1343010489,The Scuba Squad
+1343010507,CW Rename
+1343010555,Sanguis Mortus
+1343010807,Astriella
+1343010877,Slims scroll mule
+1343011194,Fisherman Steve
+1343011521,Modi
+1343011645,Kwyjibo
+1343011718,Staid
+1343011827,Hatchet Harry
+1343012317,Kwy Trinket Salvage
+1343012577,Kwy Mule
+1343012587,Kwy Salvage
+1343012784,Beastie The Daemon
+1343013216,Fletchy McCooksalot
+1343013309,Slims archer
+1343014024,Fabricator
+1343014025,Quarantine
+1343014164,Zq Armor Mule
+1343014189,I R Teh Rox
+1343014209,Zq Wardrobe
+1343014234,Zq Steel Storage
+1343014235,Zq Brass Storage
+1343014283,Zq Weapon Locker
+1343014292,Zq Salvage
+1343014297,Kwy Wardrobe
+1343014356,Zq Salvage Overflow
+1343014537,Kwy Key Holder
+1343014800,Z Fifth Element
+1343015386,Hell's Wrath
+1343015480,Ze Overburdened
+1343015696,Kwy Salvage Overflow
+1343015892,Sanguis Volta
+1343015940,Vivi-Orunitia
+1343016169,Stromgard the Dark
+1343017634,Lisa G
+1343017635,Isabel Umana
+1343017636,Carrie Lynn
+1343017637,Karen Hjorten
+1343017721,Quarantined
+1343017728,Missing Pieces
+1343018026,Nakondas
+1343018027,Tiesto
+1343019252,Dooty Tang
+1343020923,Einherjer
+1343020948,Eldgrim
+1343021340,Eldgrim's salvage
+1343021403,Eldgrim's items
+1343021446,Antidisestablishmentarianist
+1343021448,Eldgrim Salvage II
+1343021538,Eldgrim Salvage III
+1343021553,Broncanuss
+1343022658,Vlakhen
+1343022703,Poeme
+1343023584,Ordall
+1343024513,Unlawful night
+1343025131,Ordall's mule
+1343025141,Blitzen II
+1343025451,Zad Storage
+1343025453,Zad zi
+1343025454,Zad Zii
+1343025457,Zad Notes
+1343025459,Zad Salvage
+1343025462,Zad Weapons
+1343025467,Zad Ziii
+1343025489,Zad Ziv
+1343025490,Zad Zv
+1343025693,Kung Fu Hamster
+1343025853,Eldgrim's Spirits
+1343025960,Makor
+1343025989,Sanguis Sparta
+1343026221,Kilemal
+1343027677,Statim Finis
+1343027801,Einherjer le II
+1343027856,Deathofac
+1343027857,Swampduckdaddy
+1343027891,Loo-Gie
+1343027926,Sabina Pasic
+1343027927,Isabel Umana
+1343027928,Randee Caras
+1343027929,Jessica Smith
+1343027930,Chelsea Case
+1343028747,Vv
+1343030538,Bullshtien
+1343030554,Kilemal
+1343030640,Maid in the Shade
+1343031102,Gotha
+1343031530,Warscrolls Keeper
+1343032393,Myarn
+1343032527,Akea
+1343032565,Kahil
+1343033203,Carline
+1343034477,Killing Foo
+1343035942,Beez Neez
+1343036179,Civinia
+1343037232,Sgt Smurf
+1343038099,Makors Mule
+1343038343,Holden Mygear
+1343040523,Nardwuar
+1343040688,The Big Mage
+1343040968,XXX Bow
+1343041640,Elysie
+1343041948,Turbo Wolf
+1343042153,Isaac the Swift
+1343042651,Callaway'
+1343044103,Gunghorin
+1343044155,Gotha
+1343044686,Another random druid
+1343045038,Little Thor
+1343045333,Georgeta
+1343045349,Thors Mule
+1343045371,Titatium
+1343045442,Elliut
+1343045836,Killarwolf
+1343045872,Rogueanna Deerhart
+1343046096,Televangelist
+1343047402,Jon Burro
+1343047936,Lil magnus
+1343047950,Gabrielle of The North
+1343048243,Toy Scuba Steve
+1343048248,Jagermech
+1343048567,Ingeborg
+1343049018,Scythien
+1343049096,Uncle Jake
+1343049152,Xarashadow
+1343049691,Redy
+1343049851,Moving Van
+1343049960,Fenney
+1343049990,Hold a bunch
+1343050455,Rumpy Stump
+1343051033,Hagreth's Mule
+1343051336,Zalia
+1343051398,Auna
+1343051479,Slim is the man says Ikon
+1343053144,Obey
+1343053305,Trym Dk
+1343053376,Triple Axe
+1343053403,Samina
+1343053823,Congo Natty
+1343053925,Old Rednose
+1343053949,Trym Og
+1343054311,Marauder II
+1343054465,Trym The Mule
+1343054525,Old Swordmaster
+1343054634,Asdfasdfasdfsadf
+1343054744,Etheldreda
+1343055320,Trym The Armorer
+1343055321,Trym The Smith
+1343055495,Heero-Yuy
+1343055496,Bowhunterman
+1343055498,Ogmageymage
+1343055499,Chy-Lee
+1343055500,Ms Sanya
+1343056567,Grandmaster Warren
+1343056826,Tinkering Foo
+1343057869,Trym The Slave
+1343057944,Old Brawler
+1343057945,Tickleme
+1343058342,Ticklemeto
+1343058540,Byte Size
+1343058909,Prophetofdreams
+1343059357,Heathkit
+1343059450,Sour Apple
+1343059533,Virulence
+1343060466,Boss Hog Of The South
+1343060895,Handy Smurf
+1343060997,Marth X
+1343061309,Dark Tyrael
+1343064077,Gabrielle of Tid
+1343064295,Black Butterfly
+1343064298,White Butterfly
+1343064383,Gabi's mule
+1343065782,Kurukar
+1343067143,Magica DeSpell
+1343069279,Fear Purple n' Red
+1343069804,God Of Wrath
+1343070093,Darq Cricket
+1343070184,Sad Sam
+1343071278,Nekromantix
+1343072338,Zoi
+1343073151,Viamontian Steel
+1343073368,Merenwen
+1343073480,Eirene
+1343073506,Chamie
+1343073532,Thalia
+1343074346,Ispahan
+1343074426,Dez'mron Moneychanger
+1343075195,Meren
+1343075273,Quickcut
+1343075994,Kochiro
+1343076892,Old Mad Man
+1343077430,Adultry
+1343078966,Valarie Tickles
+1343079003,No Pain No Gain
+1343079287,Nehmu ibn Wynd
+1343079288,Isgrim
+1343079719,Rodgers
+1343079888,Blizzard'
+1343081078,Kilemal
+1343081465,Maximum Fahrenheit
+1343081538,Little Ricardo
+1343081724,Baby Abby
+1343081808,Chats Mule
+1343081842,Hellarious
+1343082018,He who is called I Am
+1343082111,L E G E N D
+1343082297,Calous
+1343083138,Miach Justicar
+1343083147,Onikuma
+1343083206,Townsman Miach
+1343083496,Buff Bot Miach
+1343083900,Hollow Miach
+1343084012,Bob Loblaw
+1343084146,Gerryman
+1343084377,The Interweb
+1343084408,Miach Unleashed
+1343084590,Mister choop
+1343084721,Sorry Ibn Drinkin'
+1343084956,Vn Spacelord
+1343085550,Sunrise Adams
+1343086567,Falkeye
+1343087113,Shojunc
+1343087625,Drunkin Soul
+1343088042,Vlakhen
+1343088114,Rian di Falca
+1343088176,Pvt Licker
+1343088240,Blixten
+1343088300,Dez'mron Salvager
+1343088391,Bloodsausage
+1343088565,Hobbie
+1343090574,Gaby's Daughter
+1343091413,Makidi
+1343091435,Hagreth's Storage
+1343091437,Nozo's Storage
+1343091543,Box Top
+1343091567,The Arch Killer
+1343092190,Arzon Roak
+1343092495,Logan Doom
+1343093075,Al Bow
+1343093821,Fquick
+1343093904,Fquick Ua
+1343093917,Sheetguys
+1343094041,Deadmau
+1343094090,Morak Karuzi
+1343094252,Sho Can Tinker
+1343094282,Mag-nus
+1343094300,Beale VII
+1343095253,Digiorno
+1343095706,Fquick Salvage
+1343096155,Jin-Sung
+1343096174,Bowmaster Roland
+1343097349,Heritage Skillz
+1343097428,Sanguis Lazarus
+1343097625,Anotha Mule
+1343097992,Mag-tinker
+1343098202,Leldaran
+1343098228,Yellar
+1343098235,Mag-bow
+1343098888,Mag-mules
+1343098910,Mag-mule
+1343099056,Di items
+1343099149,Ldy of the blue lagoon
+1343099403,Mag-salvager
+1343099406,P E R T U R B E D
+1343099782,Chocolate Thriller
+1343099983,Blue Da Ba Dee
+1343100156,Peace Mezzir-Garrett
+1343100201,Interplanetary Delivery Man
+1343100325,John Fogerty
+1343100338,Sun Runner D'Aerth
+1343100441,Kitsune Loreweaver
+1343100713,Sun Mule One
+1343100854,Fquick Armor
+1343101011,N a r c o t i c
+1343101356,Dollar General
+1343101513,Peace Mule One
+1343101549,Blade of Memory
+1343101795,Footaki
+1343102433,Greifer
+1343102817,Einherjer
+1343102990,Koji Incarnate
+1343103379,Brodude
+1343103442,Beale VIII
+1343103645,Peddler Dragoon
+1343103920,Fedaykin
+1343103957,Captain Dudeface
+1343103963,Notouching
+1343104161,Holden Mai'villa
+1343104435,Tory Lane
+1343104578,Metalocalypse
+1343105110,Cyborg Sausage
+1343105154,The Drudge Mule
+1343105162,Furosuto
+1343105324,Ieatsalvage
+1343105799,Walk in closet
+1343105943,Beale IX
+1343105993,Deathdualer
+1343106077,Backpac
+1343106113,Fwank
+1343106265,That name is not permitted
+1343106297,Katherine Maree
+1343106343,Buymethings
+1343106465,Wally World
+1343106549,Ironbound
+1343107299,Tryme Idareya
+1343107713,Bro-A-Palooza
+1343107900,Ein's luggage
+1343108552,Grunk Dimp
+1343109067,PL Rename
+1343110286,Cedex
+1343110335,Fear My Power
+1343110396,Coheedandcambira
+1343110400,Coheed and cambira
+1343110401,C and ca stuff maker
+1343110762,Deathmule the First
+1343110795,Sticky Situation
+1343111160,Mag-lite
+1343111324,Ton Nen-Kai
+1343111449,Cheaper Colosseum Vendor
+1343111513,Affirmative Action
+1343111516,Beale III
+1343111562,Fquicker
+1343111566,Deathumbra
+1343111654,Lieutenant Dan
+1343111711,Shan-Shan
+1343111783,Mag-aetheria
+1343111784,Mag-armor
+1343111785,Mag-misc
+1343111786,Mag-money
+1343111788,Mag-salvage
+1343112102,Cams Mule
+1343112254,Martyr Al
+1343112384,Husmor
+1343112399,Deathquester
+1343112573,Dark pixie
+1343112760,Mag-Dis
+1343112916,Deathmule the Second
+1343112919,Deathmule the Third
+1343113066,Mag-five
+1343113067,Mag-six
+1343113068,Mag-seven
+1343113351,Mag-armor good
+1343113397,Cute'
+1343113494,Mag-ivory
+1343113514,Minnidil
+1343113701,Mag-brass
+1343113702,Mag-iron
+1343113703,Mag-granite
+1343113864,Mag-leather
+1343114095,Mag-steel
+1343114156,Thou Shall Not Fall
+1343114396,Mag-armor low al
+1343114489,Kyriel
+1343114766,Jonny Quest
+1343114861,Deathgearer
+1343114934,Throwbot Fivethousand
+1343115435,Little Maja
+1343115565,The Scuba Squad
+1343115605,Mag-cov salvage
+1343115647,Mag-dbl majors
+1343115648,Mag-epic jwlry undr
+1343115654,Mag-steel two
+1343115725,Mag-steel three
+1343115784,Mag-swords
+1343115785,Mag-wands
+1343115791,Mag-armor good def
+1343116547,Mag-Colo Rings
+1343116569,Mag-Tinkers Set
+1343116804,Mag-misc weapons
+1343116805,Mag-misc set pieces
+1343116875,Talliwacker
+1343116933,Biggy Shorty
+1343116934,Bad Bitty
+1343117033,Mule Squared
+1343117138,Mag-misc jwlry undr
+1343117225,Mag-Colo Items
+1343117239,Bladefear
+1343117495,Elmstreet Horror
+1343117613,Dayman
+1343117698,Nikara
+1343117700,Manza
+1343117972,Itty Bitty Titty Committee
+1343118039,Thrillhouse
+1343118785,Oh God It Burns
+1343120057,Mag-temp a
+1343120520,Mag-stuffs
+1343120711,Deathvoider
+1343121441,Panty Sniffer
+1343122362,Slims big guy
+1343123169,Interplanetary
+1343123318,Pininfarina
+1343123964,Treselle the True
+1343124089,Old Stuff
+1343124254,I Hate This Job
+1343124767,Yoroi Orange-Gold-Black-Purple
+1343124769,Yoroi Red-Green-Blue
+1343124787,Beale X
+1343125455,Rollie Wedge
+1343125863,Asfasf
+1343125951,Messer's Revenge
+1343126047,Mezzer
+1343126349,Nozo's Mule II
+1343126529,Meseria
+1343127170,Box Top's Twin
+1343127292,Trader Dagger
+1343127720,Hagreth's Twin
+1343127943,Shomage
+1343128026,Deathweaper
+1343128028,Deatharmorer
+1343128087,Ticklemethree
+1343128112,Ticklemefour
+1343128127,Ticklemesix
+1343128208,Ticklmeeight
+1343128914,All Tickled Out
+1343129363,Gwendolyn du Avalon
+1343130039,Chief of Staff
+1343130040,Jim Bowie
+1343130042,Vitae-man
+1343130735,B-Afraid
+1343131381,Miach Champion
+1343131431,Miach Oppressor
+1343131443,Saosinn
+1343131495,Brutalis
+1343131774,Logan slim
+1343132417,You so nozey why you spy on me
+1343132713,Blue Shaman
+1343132878,Entropy Guy
+1343132953,Decal C-Sharp Dev-bot
+1343132953,Lifestone Shaman
+1343133073,The deceiver
+1343133181,C tan
+1343133747,Beale XII
+1343134006,Luginut
+1343136086,Death the Devoid
+1343136945,Slimette
+1343137258,Elizebeth
+1343137762,Franks and Beans
+1343137863,Thirteen'
+1343138843,A Courier
+1343139263,Izboy
+1343139438,Hundreng Scytheson
+1343139720,Baeelzhaarons
+1343140413,Zino
+1343142119,Nuke'em
+1343142134,Bow Flex
+1343142709,Punchster
+1343142971,Legendary Delivery Boy
+1343143005,Kottonmouth King
+1343143046,Belladona
+1343143799,Johnny Richter
+1343143799,Mayday parade
+1343144301,Ivel
+1343144304,I Throw Stuff At You
+1343144646,Metal Slime
+1343144729,Minari
+1343144897,Superconductor
+1343145040,Thirteen Blades
+1343145094,Forever Knight'
+1343145095,The Scarlet Blade
+1343145114,Super Duper
+1343146393,Hairy Muldoon
+1343146399,Ya Dig
+1343146710,Lazy Eye Miach
+1343146866,Guardian Miach
+1343146869,Miach Smurf
+1343146912,Smurf Miach
+1343146914,Bow Miach
+1343146915,Miach Bow
+1343146916,Blind Miach
+1343147338,Mulemand
+1343148531,Shady Gaga
+1343148922,Mule II du Gwendolyn du Avalon
+1343149451,George Fisher
+1343150674,Trym Ny
+1343150723,Onde Lyne Mig
+1343150981,Sam the Shiv
+1343151253,Copastetic
+1343151444,Storage IV
+1343151588,Storage V
+1343151593,Beale's Spell Components
+1343151594,Krasch
+1343151639,Beale's Quest Items and Misc
+1343151654,Beale's Armor
+1343151655,Beale's Random Salvage
+1343153513,Flash Strike
+1343153514,Flesh Strike
+1343153926,Miss Marvel
+1343154582,Gov
+1343154720,Canis Majoris
+1343155107,Coversationalist
+1343155293,Ho Mule
+1343155713,Fatass
+1343157160,Ghost of Aimaru
+1343157283,Johan van der Smut
+1343157321,Lili Von Shtupp
+1343157330,Weapon Delivery Boy
+1343157331,Legendary Delivery Boy II
+1343157451,Fiktion
+1343157896,Bash Masterson
+1343158114,Kaika
+1343158116,Legendary Delivery Boy III
+1343158117,Tailoring Dude
+1343159094,Black Mist
+1343160073,Legendaries
+1343160748,Steelmule
+1343160907,Steel mule II
+1343160929,Kitz n Shiz
+1343160930,Chest one
+1343160931,Chest two
+1343160932,Chest three
+1343161013,Steel for Sale
+1343161496,Sos Piet
+1343162118,Deathconjurer
+1343162285,Nig Nog
+1343162770,Aeriloa
+1343162877,Deathmule the Fourth
+1343162878,Deathravager
+1343162879,Deathmule the Fifth
+1343162890,Grammar Nahsi
+1343162893,Deathmule the Sixth
+1343162894,Deathmule the Seventh
+1343163000,Deathmule the Eighth
+1343163019,Deathmule the Ninth
+1343163020,Deathmule the Tenth
+1343163075,Jylie Braveheart
+1343163077,Deran Dark
+1343163272,Smasha
+1343163283,Grungeon
+1343163319,Gruedor The Troubadour
+1343163348,Gniyfingam Ssalg
+1343163382,Pachi
+1343163738,M U L E III
+1343163925,O-Too
+1343163950,Goober The Doober Smoozer
+1343163952,Muledorf
+1343163953,Greudon The Muledon
+1343164087,Esmarelda Morleigh
+1343164215,Groober The Noober
+1343164586,Aerboa Clanoa the Crying Sandtoe
+1343164819,Draknor Knightbane
+1343165088,Mega Salvage Mule
+1343165092,Mega Misc Mule
+1343165530,Weapontinksal
+1343165808,Old Spacelord
+1343165972,Chest five
+1343166731,Colost
+1343166733,Booom Booom
+1343166821,Go Boom Boom
+1343166822,Rock for brains
+1343167197,Void Einherjer
+1343167271,Lucifers' Prodigy
+1343167323,Spadone
+1343168431,Algorab
+1343168920,Mule du Gwendolyn du Avalon
+1343169247,Fericci
+1343169817,Ironhands
+1343169819,Sparkfist
+1343169826,Omglazerz
+1343169847,Mahharu
+1343169939,Blonde Smurf
+1343169957,Hermitboy
+1343170096,Deathpoker
+1343170141,Xao Mah
+1343170230,Ripvanwinkle
+1343170292,I Like Big Bots
+1343170297,Cold Knight Storage
+1343170353,Sacrificial
+1343170374,Deathmule the Eleventh
+1343170547,Jonsuxpp
+1343170637,Hayate Ayasaki
+1343170685,Deadite
+1343170687,Mahh Spellz
+1343170760,Shangtsung
+1343170903,Heldgrim
+1343171078,The Tenderizer
+1343171091,Deletorious
+1343171570,Smurfs Allot
+1343171694,Nahamston
+1343171815,Schala du Avalon
+1343172279,Boidomeiji
+1343172419,I Call Him Leggs
+1343172455,Constance Green
+1343172729,Peppah
+1343173241,Splitshaft
+1343173265,Quintillus
+1343173372,Chest four
+1343173451,Horrideus
+1343173641,Sanguis Tenebrous
+1343173644,Caerlean
+1343173689,Apsu
+1343173755,Elsydeon
+1343173756,Fiona Starcaster
+1343173758,Shau'ri Starshard
+1343173781,Amin Ra
+1343173886,Elyssa Nightbane
+1343173936,Deathmule the Twelfth
+1343173940,Deathmule the Thirteenth
+1343174118,Gear Kweer
+1343174305,Sanguis Sitis
+1343174461,Insert coin
+1343174539,Diogenes Pendergast
+1343174555,A'mee
+1343174619,Furota
+1343174634,Mrs Grey
+1343174655,Beale's Wands
+1343174659,Beale Bows
+1343174663,Miss Blue
+1343174668,Kara Zor-El
+1343174761,Lunette Xylia
+1343175064,Gelidite
+1343175072,Iron Chef Akal
+1343175139,Hitachino
+1343175395,The Drudge Mule III
+1343175478,Hiro Blademaster
+1343175508,Tuff Shed
+1343175560,A Blacksmith
+1343175769,Akal Saris
+1343176118,Dragula
+1343176359,Mule of Ripley
+1343176511,Beale's Summons
+1343176517,Beale Steel
+1343176518,Beale Brass
+1343176622,Derpa derp
+1343176642,Vey lamule
+1343176986,Perrin al'Thor
+1343177206,Fortunato di Fausto
+1343177207,Beale's Weapons
+1343177209,Beale's Shadow
+1343177211,Beale XV
+1343177212,Beale's Di Items
+1343177252,Beale's Ivory
+1343177267,Beale's Brass
+1343177268,Beale's Colored Yoroi
+1343177269,Beale Green Garnet
+1343177376,Beale Steel II
+1343177600,I Hold Items
+1343177645,Cryptic Storm
+1343177838,Cosmic Microwave Background
+1343178046,I Hold Stuf Too
+1343178047,Item Mule
+1343178048,Item Mule III
+1343178050,Item Mule V
+1343178052,Item Mule VII
+1343178053,Item Mule VIII
+1343178113,The Drudge Mule IV
+1343178191,Inky Shadow
+1343178243,Beale's Underclothes
+1343178252,Beale's Quest Items
+1343178256,Beale's Bank
+1343178390,Beale's Colored Yoroi II
+1343178533,Dot Dot Dot
+1343178664,B E A L E
+1343178665,Vinnie Paz
+1343178678,Beale's Ivory II
+1343178714,Slayer Miach
+1343178932,Beale Bows II
+1343178934,Beale's Wands II
+1343178935,Beale's Trinkets
+1343178936,Beale's Rares
+1343178939,Beale's Cloaks
+1343178942,Beale's Rings
+1343178944,Beale's Bracelets
+1343178945,Beale's Mahogany
+1343178947,Beale's Wise Set
+1343178948,Beale's Trinket Salvage
+1343178967,Beale's Leather
+1343178968,Beale's Adept Set
+1343178969,Beale's Defender Set
+1343178970,Beale's Dex Set
+1343178973,Beale's Aetheria
+1343179164,Aestourn
+1343179212,Nano diablo
+1343179227,Kama Koze
+1343179227,Welldang
+1343179342,Rank Void
+1343179650,Salvatore Folgeretti
+1343179856,Muleylugey
+1343179858,Yar
+1343179898,Ironn Man
+1343180421,Darth Crash
+1343180422,Darth Klatu
+1343180429,Hermit Lord
+1343181297,Two killer
+1343181298,Tufor Thesho
+1343181374,Armor Designs
+1343181420,Beale Ivory III
+1343181422,Beale Steel III
+1343181434,Verata Lord
+1343181529,Gear Al
+1343181532,Beale Ivory IV
+1343181533,Beale Ivory V
+1343181559,Beale Diamond Powder
+1343181769,Beale XX
+1343181783,Beale Temp Storage
+1343181786,Beale Temp Storage II
+1343181787,Beale Temp Storage III
+1343181788,Beale Temp Storage IV
+1343181789,Beale Temp Storage V
+1343181790,Beale Temp Storage VI
+1343181791,Beale Temp Storage VII
+1343181794,Beale Temp Storage VIII
+1343181796,Beale Temp Storage IX
+1343181797,Beale Temp Storage X
+1343181798,Beale Weapon Skins
+1343181880,Carlos Danger
+1343181888,Beverlyanne
+1343182032,Beale Colo Rings
+1343182037,Beale Colo Rings II
+1343182133,Beale Weapon Skins II
+1343182145,Beale Mansion Kit
+1343182162,Ailea
+1343182178,Beale's Underclothes II
+1343182235,Arrtoo Deetoo
+1343182239,Beale Moonstone
+1343182240,Beale's Wands III
+1343182241,Beale's Weapons II
+1343182243,Beale Colo Rings III
+1343182244,Beale Colo Rings IV
+1343182252,Beale Bows III
+1343182254,Beale Colo Rings V
+1343182255,Beale C Temp
+1343182282,Beale Necklaces
+1343182298,Beale Ten Tink Armor
+1343182460,Beale Colo Rings VI
+1343182471,Scel
+1343182488,Harambe
+1343182549,Nocc Temp
+1343182561,Some Salvage
+1343182592,Encap Spirits
+1343182610,Obama Care
+1343182611,Slapchop
+1343182644,Trash Panda
+1343182710,Proms
+1343182754,Hitlore
+1343182885,Eight Foot Freak
+1343182893,Kronos Lord
+1343182949,Totes lit fam
+1343182986,Dwight Schrute
+1343183047,Armadillo
+1343183051,The Last Portal
+1343183052,Brialmont
+1343183060,Simgear
+1343183114,Tunzi
+1343183143,Greg Graffin
+1343183179,Celph Titled
+1343183180,One Last Skree
+1343183184,Deathbower
+1343183188,Ghjhhtyutru
+1343183194,Isabel Umana
+1343183196,Heather Downey
+1343183197,Liz Bouiss
+1343183198,Cristina Herrera
+1343183199,Karen Hjorten
+1343183200,Gita Stephan
+1343183266,Bliz Eno Renard
+1343183785,Griij the Alkemyst
+1343184151,Santa Bob
+1343184209,Cimmerian Shade
+1343184407,Doubletap
+1343184433,Doom Man
+1343184607,The Drunken Dagger
+1343184687,Flex Buffchest
+1343184702,Pubbie James
+1343184710,Daisy Pushover
+1343184748,Putrefy
+1343185102,Erebos
+1343185171,Mechanism
+1343185195,Shade of Legato
+1343185205,Patrick Darkarrow
+1343185796,Burfen
+1343186046,Xoatl
+1343186169,Yolandi Visser
+1343186237,Courage Wolf
+1343186604,Mantis Toboggan
+1343187021,Koverasi
+1343187198,Maelwig
+1343187688,Blodcniht
+1343188158,Dkoreas
+1343188159,Kiri bint Saris
+1343188529,Wuldor
+1343188955,Dez'mron Armory
+1343189038,The Drudge Mule V
+1343189293,Darkk Valyn
+1343189879,Tarball
+1343189900,Drumbeater
+1343190264,Gerod
+1343190271,Darq chocolate
+1343190293,Cartimandua
+1343190410,Raukowath
+1343190434,Kurathzia
+1343191381,Dez'mron Armorer
+1343191382,Dez'mron Smithy
+1343191383,Ranlyn
+1343191384,Somilar
+1343191385,Dez'mron Loremaster
+1343191399,Dez'mron Trader
+1343191400,Marek Vagnard
+1343191401,Feral Intendant
+1343192696,Cait Sidhe
+1343192799,Aun-Festivus
+1343193128,Bliz Renard
+1343193408,Help i don't know how to exit th
+1343193415,Embertide
+1343193486,Speppy bringus
+1343193814,Syrup
+1343193889,The Drudge Mule VI
+1343193891,The Drudge Mule VII
+1343193892,The Drudge Mule VIII
+1343193893,The Drudge Mule IX
+1343193894,The Drudge Mule X
+1343194769,Meet Your Doom
+1343194804,Deeza
+1343194913,Gwolchming
+1343194972,Into The Abyss
+1343195125,Abahl
+1343195214,Eryx
+1343195307,Tehmoole
+1343195425,Blueberry'
+1343195427,Aeryx
+1343195544,Tiderius
+1343195545,Arbitar
+1343195894,Flashyflash
+1343195943,Love'
+1343196092,Deeza's Mule lol
+1343196235,Jimmytehhater
+1343196237,Wuzzzzabing
+1343196277,Undead Courier
+1343196344,Deeza's Mule Two lol
+1343196394,Loogie Anne
+1343196476,Noigel
+1343196536,Hand of Doom
+1343196542,Tmone
+1343196590,Garthak
+1343196597,Snarfle
+1343196649,Frickin Fugly
+1343196840,Malleus
+1343197058,Aaroniero Arruruerie
+1343197060,Deeza's Mule Four lol
+1343197062,Keymaster
+1343197160,Treebark
+1343197199,Miss Doom
+1343197492,Large Packs
+1343197947,My Armor
+1343197951,So here's some gear
+1343198095,Hock a Lugi
+1343198096,Lugi Hocker
+1343198179,Jopen
+1343198950,My Gear
+1343199164,Bunnu
+1343199230,K'itara
+1343199430,Pack Space
+1343199844,Anastasia Steele
+1343200420,Sereg Palan
+1343201227,Top Tier Loot
+1343201732,Darq Perro
+1343202076,Caldwig
+1343202254,Aelmar Matisse
+1343202515,Russet
+1343202815,Grand Casino Chest
+1343203805,Mah Rocks
+1343203852,Peace Mg
+1343204520,M U L E IIII
+1343204530,Yam Festival
+1343204614,Mr A
+1343204620,Blazing Sun
+1343204950,Geggy Tah
+1343205181,Olthoi Bug
+1343205329,Spear Chuker
+1343205496,M U L E IIIII
+1343205630,Incantation of Components
+1343205828,Shadow of Liberty
+1343205954,Divertimento
+1343206029,Steel Mill
+1343206496,Stentorian II
+1343206591,X Bow
+1343206604,Dark Malzar
+1343206653,Axiom Rage
+1343206673,Void Summoner Eridyn
+1343206676,Zechar
+1343206690,Raxem
+1343206783,Spacelord le II
+1343206812,Eridyn at the End
+1343206820,Ash Anor
+1343206822,Axiomwin
+1343206835,Fuuucwb
+1343206889,Kayame
+1343206895,Salvaged Bone
+1343206896,Goodbyeac
+1343206897,Kuwashi
+1343206908,Hold my junk
+1343206928,Purpley Guy
+1343206939,Pleasantspecter
+1343206948,Fatslim
+1343206959,Shootey McWarwand
+1343206961,Heather Downey
+1343206962,Isabel Umana
+1343206963,Theresa Herrera
+1343206964,Liz Bouiss
+1343206965,Karen Hjorten
+1343206966,Cristina Herrera
+1343207321,Onceler
+1343208425,Rhien
+1343208474,Excessum
+1343208477,A T B
+1343208522,Arkai
+1343209393,Dread Blade
+1343209409,Winslow the Quick
+1343209681,M U L E VI
+1343210271,More Packs
+1343210387,Even More Packs
+1343210519,Joffrey
+1343211440,Rein of Darkness
+1343211619,Holder of 'da Goods
+1343211620,Legendary Barney
+1343211716,Pygoscelis
+1343211934,Kalashan
+1343212009,In Living Color
+1343212012,Grundaar
+1343212054,Mec Qui Tombe Dans L'Vide
+1343212261,I'm Another Pack
+1343212614,Blacksteel Golem
+1343212938,Aloysius Pendergast
+1343213470,Hoar
+1343213857,Kvothe
+1343213924,Vashet
+1343214780,Cyberkiller
+1343215098,Bunnec
+1343215740,Tinkertron
+1343215801,Legacyholder
+1343215943,Zaras the Summoner
+1343217548,Myrrlin
+1343217646,Aleyn
+1343217819,Buffoon
+1343218051,Dolt
+1343218054,Dimwit
+1343218201,Bob's Rare Mule
+1343218202,Bob's Aetheria Mule
+1343218251,Bob's Item Mule
+1343218304,Bob's Spell Comps
+1343218923,Bob's Armor Mule
+1343219975,Rosewhine
+1343220042,Zometh Hypemist
+1343220064,Elite Wares
+1343220239,Skrilex
+1343220328,Void Al
+1343220394,Gais
+1343220613,Muleington
+1343220631,Xanxin
+1343220710,Reverse osmosis
+1343220721,Muleingtoni
+1343220843,Dummy
+1343220844,Numb Skull
+1343220845,Dullard
+1343220891,Chat Mule
+1343220900,Elite Wares II
+1343221088,Celeth
+1343221089,Blvit
+1343221089,Elite Wares III
+1343221188,Muleington the third
+1343221346,Dis R Us
+1343221527,Xioxin
+1343221528,Lummox
+1343221529,Chowderhead
+1343221537,Thick
+1343221547,Kaean
+1343221673,Bob's Quest Armor
+1343221707,Kaiju
+1343222041,Bob's Foolproof
+1343222042,Bob's Attic
+1343222043,Bob's Crafting Supplies
+1343222098,Bob's Cloaks
+1343222102,Bob's Tailoring Mule
+1343222103,Bob's iewelry Mule
+1343222104,Bob's Quest Weapons
+1343222109,Safe Deposit Box
+1343222144,Mulegbg
+1343222254,Pushu
+1343222255,Pushu Tuu
+1343222389,Pacipaw
+1343222652,Belizu
+1343222653,Litle Girl
+1343222654,Daidarabotchi
+1343223502,Strong Arm Numb
+1343223671,Phantasi
+1343223907,Chuchu Chizen
+1343224440,Limondir
+1343224777,Ciel Cadelanne
+1343225697,The Skuggan
+1343225874,Ripley's Resurrection
+1343226029,Winter Fennec
+1343226030,Eli Sharpclaws
+1343226034,Yamaguchi Tsutomu
+1343226457,Liamh
+1343226628,Kaleja
+1343227361,The Drudge Mule XI
+1343227365,Exchequer
+1343227717,Mads
+1343227970,The Drudge Mule XII
+1343227973,The Drudge Mule XIII
+1343228128,Gold Hold
+1343228164,Arkaina
+1343228296,Cheleth
+1343228480,Liman
+1343228524,Khatina
+1343228528,Daiki
+1343228661,Sommar
+1343228830,Akatsuki
+1343228831,Nh Rep
+1343228993,Hub items and gold letters
+1343229653,Tidedoom
+1343229742,Caveman Rare Holder
+1343229861,Bob's Brass
+1343229897,Ugly the Caveman
+1343229903,Bob's Finesse Weapons
+1343229905,Bob's Heavy Weapons
+1343229907,Bob's Light Weapons
+1343229908,Bob's Wands
+1343229909,Bob's Missile Weapons
+1343229910,Bob's Two Handed Weapons
+1343229911,Bob's Summon Mule
+1343229917,Xyzzzzy
+1343229918,Xyzzw
+1343229921,Bob's Steel
+1343229927,Bob's Squire
+1343229949,Qarkai
+1343230091,Arkai's Mule
+1343230110,Old Hatter
+1343230271,Double A's
+1343230343,Zylkari the Armorer
+1343230395,Isolte
+1343230529,Caveman Quartermaster
+1343230608,Old Log the Axer
+1343230613,Trym The Hothead
+1343230620,Lamie
+1343230668,Arkaina's Mule
+1343230915,Clyde Arrowny
+1343231107,Aganaroth Teenager
+1343231230,Qarkai's Mule
+1343231302,Nugoh
+1343231429,Emulio'
+1343231468,Trym the Mage
+1343231473,Trym the Mighty
+1343231477,Old Goose
+1343231662,Kicki
+1343232335,Meduka
+1343232336,Disregard Gravity
+1343232340,Charone
+1343232341,Chartwo
+1343232344,Charthree
+1343232348,Charfive
+1343232350,Charsix
+1343232352,Charseven
+1343232354,Chareight
+1343232379,Avald Frosteye
+1343232639,Old Man Mose
+1343232875,Basmel
+1343232880,Lokei
+1343233094,Emulio Jr
+1343233436,Emblem Rhapsody
+1343233774,Trym The Clog
+1343233792,Enceladus
+1343233799,Preon
+1343233936,Hc Mode
+1343234297,Ark's Mule
+1343234348,Craftmaster Chrom
+1343234433,Arkaii
+1343234434,The Black Death'
+1343235027,Korrupt
+1343235106,Surefluff
+1343235233,Bigdumbluggie
+1343235265,Orwen
+1343235280,M U L E VII
+1343235636,Bunnu's Melee Weapon Mule
+1343235641,Bunnu's Useful Misc Mule
+1343235645,Bunnu's Other Weapon Mule
+1343235646,Bunnu's Legendary Skills Mule
+1343235648,Bunnu's Legendary Ward Mule
+1343235649,Bunnu's Armor Mule
+1343235650,Bunnu's Misc Mule
+1343235664,Bunnu's Equipment Mule
+1343235666,Bunnu's Armor Mule II
+1343235676,Bunnu's Armor Mule III
+1343235709,Bunnu's Misc Mule II
+1343235730,Bob's Keys
+1343235755,Katharin Pazzadea
+1343235857,Rinadu
+1343235886,Bob's Quest iewelry
+1343236213,Void Miach
+1343236514,Farlon
+1343236973,Bob's Green Garnet
+1343236974,Bob's Iron
+1343236975,Bob's Granite
+1343236976,Bob's Hog
+1343236977,Bob's Misc Salvage
+1343237249,Bob's Consumables
+1343237784,Yari Ashigaru
+1343237802,Ark's Fletcher
+1343238026,Colorful
+1343238564,Ark's Salvage
+1343238738,T B D
+1343239147,Yui Hirasawa
+1343239151,Nodoka Manabe
+1343239275,Gov's Mule
+1343239300,Cuddly Rabbit
+1343239388,Inferno Of Death
+1343239390,Velveteen Olthoi
+1343239710,Bob's Armor Mule II
+1343240325,Arie
+1343240387,Bob's Item Mule II
+1343240388,Bob's Attic II
+1343240410,Bob's Shields
+1343240414,Bob's Cloth
+1343240415,Bob's Temp Mule
+1343242659,Aridack
+1343242696,Fluffiest Bunny
+1343243723,Snowypaws
+1343244193,O-Tugak Me
+1343244201,Casimiro
+1343244298,Shadowtwo
+1343244680,Stramus
+1343246898,Professor Bob
+1343247731,Duna the Dain
+1343247737,Main the Dain
+1343247745,Tain the Dain
+1343247764,Dulle the Hat
+1343247766,Give the Hat
+1343247767,Dina the Hat
+1343247769,Rain the Dain
+1343247788,Sanguis Necrosis
+1343247790,Sanguis Gigas
+1343247845,Gina the Hat
+1343247847,Lane the Dain
+1343247848,Thain the Dain
+1343247849,Line the Hat
+1343247850,Dima the Hat
+1343247889,Bob's Armor Mule III
+1343248266,Xantia the Hat
+1343248270,Xantia the Dain
+1343248607,Zacha the Hat
+1343248791,Bob's iewelry Mule II
+1343248943,Shaiky
+1343248997,Mr Steel Mule
+1343248998,Mr Brass Mule
+1343248999,Mr Rends
+1343249001,Mr Leg Armor
+1343249003,Mr Bling
+1343249004,Mr Leg Weps
+1343249005,Mr Noob Gear
+1343249006,Mr Random
+1343249022,Mr Loot
+1343249050,Vektor
+1343249084,Sho Slave
+1343249192,Zenia the Dain
+1343249202,Zenia the Hat
+1343249222,Zentia the Hat
+1343249396,More Noob Gear
+1343249481,Brass Eye
+1343249514,Iron Granite
+1343249561,Mr Rares
+1343249629,Bob's Quest Armor II
+1343249793,More Steel
+1343249974,Randommm
+1343249975,Randommmm
+1343249976,Randomm
+1343249977,Randommmmm
+1343249978,Randommmmmm
+1343249979,Randommmmmmm
+1343249980,Randommmmmmmm
+1343249981,Randommmmmmmmm
+1343249984,Ramdong
+1343250011,T-Force
+1343250055,Deadshot Miach
+1343250056,Mage of the Void
+1343250057,Brute Miach
+1343250117,Deezhaha's Armor
+1343250205,Bob's Attic III
+1343250287,Im Poisonivy
+1343250343,Im Catwoman
+1343250504,Go Green
+1343250538,Altoids
+1343250716,Unattended Combat Macro One
+1343250758,Boopa di Snoot
+1343250852,Daicon
+1343250977,Key-ji
+1343251085,Zyzzy
+1343251086,Zyzygy
+1343251087,Zygomatic
+1343251138,Zana the Dain
+1343251139,Zara the Hat
+1343251196,Xerox the Dain
+1343251304,Away From Keyboard
+1343251305,Bathtub
+1343251381,Flinkif
+1343251606,Zyggy
+1343251607,Zygmund
+1343251952,Jhinna
+1343252348,Bob's Quest Weapons II
+1343252660,Port-A-Port
+1343254491,Boopa du Snoot
+1343254821,Fastest Two Seventy Five Ever
+1343254893,Mulesaa
+1343254894,Mulesab
+1343254895,Mulesac
+1343254896,Mulesad
+1343254897,Mulesaf
+1343254898,Mulesag
+1343254921,Mulesae
+1343254922,Mulesah
+1343255011,Z-Steelz
+1343255013,Z-Ironzmulez
+1343255105,Z-Housemulez
+1343255461,Claire Kanina
+1343255624,Green Taxi
+1343255627,Hydroptic
+1343255712,Blue Taxi
+1343255751,Red Taxi
+1343255825,Killerolthoi
+1343255884,Taxicab
+1343255905,Xel of Holt
+1343255954,Housing Mule
+1343255987,El Clasico
+1343256005,Ripley of Frostfell
+1343256006,Ragan the Clone
+1343256068,Headed to Shard Memorial
+1343256076,Aka-steve
+1343256079,Isabel Umana
+1343256098,Last day boys
+1343256127,Snowbunnec
+1343256137,Theresa Herrera
+1343256138,Carrie Vander Ven
+1343256139,Heather Downey
+1343256140,Kara Finch
+1343256141,Liz Bouiss
+1343257353,The Baron of Colier
+1343259270,Tabitha Stonebreaker
+1343259288,Dirty Lewdian
+1343261289,Arts n Crafts
+1343261291,Wub
+1343261379,Wubauri
+1343263539,Hamud ibn Rafik
+1343263618,The Drudge Mule XIV
+1343263619,The Drudge Mule XV
+1343263620,The Drudge Mule XVI
+1343263923,Eviction Notice
+1343263947,Burglar
+1343264226,Harlune the Misanthrope
+1343264535,Pulse Omega
+1343265138,Petty Theft
+1343265159,Grand Larceny
+1343265161,Robbin' da Hood
+1343265162,Slash Ann's Little Sister
+1343265385,Roid Rage
+1343265421,Garbage Disposal Unit
+1343265643,Tim Gunn
+1343267365,Frej
+1343267405,Tinker Toys II
+1343267425,Long John Silver
+1343267426,Pittsburgh Stealer
+1343267758,Miss Taken Identity
+1343268056,Alphabeat
+1343268613,Doombringor
+1343270995,A Wilhelm Scream
+1343271570,Drakenn
+1343272674,Ambiguous Ace
+1343273342,Amway Jane
+1343273344,Gibby Haynes
+1343274028,Tumescent Tumerok
+1343274029,Tuck Fard
+1343275121,Caerlean
+1343275482,Tuskapoo
+1343275484,Octavione
+1343275485,Octavitwo
+1343276379,Husband
+1343276592,Junk in the Trunk
+1343277074,Hugo Boss
+1343277255,Arm Er Awl
+1343277693,The Drunken Madman
+1343277697,The Guardian of the Lost Light
+1343277735,The Baroness of Colier
+1343277736,Colier Mine First Shift Foreman
+1343277740,Colier Savings and Loans
+1343277741,The Custodian of Colier
+1343277742,Colier Credit Union
+1343277783,Made Custom
+1343278110,Husband I
+1343278123,Husband II
+1343278135,Husband III
+1343278143,Husband IV
+1343278158,Husband V
+1343278173,Husband VI
+1343278182,Husband VII
+1343278197,Husband VIII
+1343278206,Husband IX
+1343278218,Husband X
+1343278225,Puttaren
+1343278916,Cripple Creek
+1343279277,Chief Mulebeater
+1343279436,The Scuba Squad
+1343282674,Daralin
+1343283173,Tingalayo
+1343285614,Manza
+1343285711,Malzar
+1343286120,Chevalier de Avaritia
+1343286202,Mcnoodle
+1343286866,Mmd General Store
+1343286989,Rupert Everton
+1343287005,Tinker McBaggins
+1343287902,Thirteen Blades
+1343290222,Jo-Lee Jheuh
+1343290911,Bytes
+1343291372,Warmech
+1343291498,Fghfghfgasz
+1343291499,Dereth Daily Deals
+1343291848,Gigabyte
+1343292051,Terabytes
+1343292804,Dieter The Black
+1343293368,Magic Trap
+1343293369,Rainbow Table
+1343293947,Eridyn of the Dark
+1343294834,Bytes Temp Mule
+1343294856,Artemis Clyde Frog
+1343295584,Mr Baker II
+1343295923,Dreams Mistress
+1343295924,Dreams Salvage
+1343296498,Petabyte
+1343297547,Mr Holds Alot
+1343297577,Kekeke
+1343298277,Malchir
+1343298677,Gfhjghjgyjhfg
+1343298822,Futz
+1343298826,Dshjklhgfd
+1343298831,I love rome
+1343299804,Adx
+1343299891,Mahika
+1343300482,Mitosis
+1343300831,Bytes the Shadow
+1343300937,Darkk
+1343301091,Ferah Palacost
+1343301109,Cal's Alch
+1343301111,Palacost Tink
+1343301116,Callaway
+1343302533,Vistar
+1343302534,Darnas
+1343302749,Drink the Salvage
+1343304095,The Fuzz'
+1343305228,Majorscl
+1343305722,Mailia
+1343305829,The Mustaffa
+1343306431,Aetheria
+1343306434,Caulnalain
+1343306436,Count Renari
+1343306447,Frelorn
+1343306453,Quest Timer
+1343306567,Mirko cro cop
+1343307505,Cygmus
+1343308321,Perrin Ayabara
+1343308425,Salvage is heavy
+1343308726,Bronze Wind-up Gearknight
+1343309000,Das Salvage
+1343309124,Wanderlei
+1343309812,Majors Are Heavy
+1343309822,Mauricio 'Shogun' Rua
+1343309900,Babywipe
+1343313261,Elo's Gk
+1343313960,Evil's Gk
+1343314822,Amuli and Celdon
+1343316647,Alex Graham
+1343319479,Ubereem
+1343319857,Mag-newb armor weap
+1343320295,Mag-tinker
+1343320424,Mag-nus
+1343320425,Mag-six
+1343320429,Fquicker
+1343320456,Mag-lite
+1343320459,Mag-five
+1343320491,Mag-seven
+1343320613,Fquick
+1343320614,Mag-Salvager
+1343320724,Elorean
+1343325481,Emme
+1343325482,Shen Do
+1343326097,Mag-z ivory
+1343326098,Mag-z colo rings
+1343326311,Mag-z money
+1343326312,Mag-z comps
+1343326313,Mag-z bling
+1343326314,Mag-z underwear
+1343326315,Mag-z swords
+1343326316,Mag-z wands
+1343326317,Mag-z aetheria
+1343326919,Mag-z Set Adept Wise
+1343326920,Mag-z Set Defender
+1343326921,Mag-z Set Hearty Soldier
+1343326923,Mag-z Set Other
+1343326924,Mag-z Armor
+1343327058,Mag-z foolproof
+1343327542,Mag-z cov salvage
+1343327589,Mag-z alduressa
+1343327632,Mag-z brass
+1343327633,Mag-z green garnet
+1343327634,Mag-z iron
+1343327635,Mag-z granite
+1343327636,Mag-z gc salvage
+1343327637,Mag-z misc salvage
+1343327757,Mag-z steel a
+1343327885,Mag-z alduressa b
+1343328174,Mag-z tenassa
+1343328327,Mag-z steel b
+1343328664,Mag-z leather
+1343328679,Mag-z colo items
+1343328931,The Stoner
+1343330247,Nonami
+1343331256,Ulm
+1343331407,Nester
+1343334574,Shadow Caller
+1343334951,Vain Glory
+1343340465,Colier Mine Second Shift Foreman
+1343340493,Jinto Wex
+1343340495,Celdin
+1343340530,Colier Mine Chef
+1343340645,Sevenofnine
+1343340677,Deceptive Cadence
+1343340733,Colier Granite Quarry
+1343340751,Colier Steel Works
+1343340752,Colier Brass and Metallurgy
+1343341673,Colier Farm Assist
+1343342055,Dad Blaster
+1343342059,Hasselblad
+1343342161,The Guardian of Lost Light
+1343342738,Noble Fir
+1343342739,Grand Fir
+1343342740,Sacred Fir
+1343342741,Giant Fir
+1343342742,White Fir
+1343342744,Corkbark Fir
+1343342750,The Drudge Mule XVII
+1343343113,The Drudge Mule XVIII
+1343343114,The Drudge Mule XIX
+1343343115,The Drudge Mule XX
+1343343117,The Drudge Mule XXI
+1343343118,The Drudge Mule XXII
+1343343120,The Drudge Mule XXIII
+1343343121,The Drudge Mule XXIV
+1343343122,The Drudge Mule XXV
+1343343123,The Drudge Mule XXVI
+1343343124,The Drudge Mule XXVII
+1343343125,The Drudge Mule XXXVII
+1343343126,The Drudge Mule Xlvii
+1343343127,The Drudge Mule Lvii
+1343343128,The Drudge Mule Lxvii
+1343343129,The Drudge Mule XXVIII
+1343343130,The Drudge Mule XXXVIII
+1343343131,The Drudge Mule Xlviii
+1343343132,The Drudge Mule Lviii
+1343343133,The Drudge Mule Lxviii
+1343343134,The Drudge Mule XXIX
+1343343135,The Drudge Mule XXXIX
+1343343136,The Drudge Mule Xlix
+1343343137,The Drudge Mule Lix
+1343343138,The Drudge Mule Lxix
+1343343139,The Drudge Mule XXX
+1343343140,The Drudge Mule Xl
+1343343141,The Drudge Mule L
+1343343142,The Drudge Mule Lx
+1343343143,The Drudge Mule Lxx
+1343343144,The Drudge Mule XXXI
+1343343145,The Drudge Mule Xli
+1343343146,The Drudge Mule Li
+1343343147,The Drudge Mule Lxi
+1343343148,The Drudge Mule Lxxi
+1343343150,The Drudge Mule XXXII
+1343343151,The Drudge Mule Xlii
+1343343152,The Drudge Mule Lii
+1343343153,The Drudge Mule Lxii
+1343343154,The Drudge Mule Lxxii
+1343343155,The Drudge Mule XXXIII
+1343343156,The Drudge Mule Liii
+1343343157,The Drudge Mule Lxiii
+1343343158,The Drudge Mule Xliii
+1343343159,The Drudge Mule Lxxiii
+1343343160,The Drudge Mule XXXIV
+1343343161,The Drudge Mule Xliv
+1343343162,The Drudge Mule Liv
+1343343163,The Drudge Mule Lxiv
+1343343164,The Drudge Mule Lxxiv
+1343343165,The Drudge Mule XXXV
+1343343166,The Drudge Mule Xlv
+1343343167,The Drudge Mule Lv
+1343343168,The Drudge Mule Lxv
+1343343169,The Drudge Mule Lxxv
+1343343170,The Drudge Mule XXXVI
+1343343171,The Drudge Mule Xlvi
+1343343172,The Drudge Mule Lvi
+1343343173,The Drudge Mule Lxvi
+1343343174,The Drudge Mule Lxxvi
+1343343392,House Mulio
+1343343418,House Emulio
+1343343483,Decal Dev Bot
+1343343702,Rand Cadelanne
+1343343703,Lailah Cadelanne
+1343343704,Sorey Cadelanne
+1343343705,Mikleo Cadelanne
+1343343706,Artorias Cadelanne
+1343343720,Mildryth Cadelanne
+1343343738,Heldalf Cadelanne
+1343343740,Tarkus Cadelanne
+1343343741,Aelfwyth Cadelanne
+1343344695,Zhapaj ibn Cadelanne
+1343346493,Cat Devnull
+1343348578,Kaveatta
+1343348989,Colier Librarian
+1343349087,Idshaya al-Xi
+1343349361,Carrion Baggage
+1343349694,Carrion Salvage
+1343350262,Carrion Rares
+1343350414,Carrion Legendary
+1343350477,Carrion Weapons
+1343350748,Ellipses
+1343350751,Asterism
+1343351899,Carrion Legenderriere
+1343353203,Eleaneth
+1343353397,Finessica
+1343354036,Carrion Lugiandary
+1343354417,Mother Mo Fo Mage
+1343354684,Muleington
+1343354693,Xanxin
+1343354700,Havarti
+1343354839,Carrion Klamotten
+1343355219,Salv Armor
+1343355221,Tomrum
+1343355444,Carrion Joules
+1343355505,Kreapist
+1343355584,The Archangel Castiel
+1343355586,The Black Ferah
+1343355667,Colier Contraband
+1343355933,Vote Eps for Mayor
+1343356124,Jean Paul Gaultier
+1343356259,Krigs Magiker
+1343356288,Essence of Beauty
+1343356400,Acidik
+1343356403,Cowhead
+1343356693,Colier Five and Dime
+1343356744,I got small DiTs
+1343356812,Colier Chorizite Refinery
+1343356859,Coded
+1343356984,Eps' Butt Plug
+1343356998,Risen Martine
+1343357048,Aleska
+1343357091,White Guilt
+1343357115,Kinzie
+1343357191,Zero Point Energy
+1343357223,Reinhold
+1343357275,Smeghead
+1343357283,Lil'lug
+1343357334,Little Ben
+1343357381,Newbiess
+1343357382,Stackoverflow
+1343357393,Stackoverflowerror
+1343357402,Right in the Feels
+1343357430,Candeth Menacet
+1343357489,Guld pojken
+1343357500,Ragan the Wanderer
+1343357513,Packets
+1343357525,Yanno
+1343357531,Heavy Night
+1343357542,Pleasantspecter
+1343357547,Kinzie
+1343357551,Kha'ran
+1343357558,Vanarthus
+1343357570,Avita Millman
+1343357580,Heather Downey
+1343357581,Theresa Herrera
+1343357582,Carrie Lynn Vander Ven
+1343357583,Elsie Missen
+1343357584,Elizabeth Bouiss
+1343357585,Isabel Umana
+1343357586,Karen Hjorten
+1343357587,Tana Mattson
+1343357625,Interplanetary
+1343358263,Yoroi Orange Black Gold
+1343358264,Yoroi Red Green Blue Purple
+1343358770,Koji's Beast
+1343359410,Annuwen
+1343359413,Aiobhann
+1343359423,Cymraine
+1343359426,Scatha
+1343360044,Yoroi Blue Purple
+1343367440,Absaroka
+1343368060,Morain
+1343374794,Slaanesh
+1343382061,Luge
+1343382068,Lugey
+1343383606,Vandominus
+1343384495,Legendaries
+1343384587,Solstice of Shade
+1343384844,Soldier's Supplies
+1343384884,Hearty and Dex
+1343384908,Adept and Defender's
+1343385129,Might of the Bow
+1343385133,Blighted
+1343385143,Andrew Carnegie
+1343385444,The Lugian Supplier
+1343385573,Another Storage Lugian
+1343385723,Mule De'Lugian
+1343386099,Jakka
+1343386153,Evil Callaway
+1343386279,Tachikoma
+1343386412,Jak Holden
+1343387060,Jak Heavy
+1343388113,Xaioxian
+1343389473,The name is Bond James Bond
+1343389474,Apple iphone
+1343389476,L M F A O
+1343391956,Leica
+1343393781,Kofi
+1343393782,Khali
+1343395639,Sanux
+1343397387,Marlise
+1343397491,Katherine Maree
+1343397831,Jak Sv
+1343398896,Jak bs
+1343399164,Liqe M'Diqe
+1343399850,Cyberkilla
+1343400110,Emulio Estevez
+1343400216,Emulio Chavez
+1343400227,Emulio Miguel
+1343400256,Emulio Gonzo
+1343400455,Emulio Fernandez
+1343400528,Wallawallabingbang
+1343400896,Bwoon Dub
+1343400897,Funny Little Man
+1343400903,Xepha
+1343400908,Rafinko
+1343400912,High Rule
+1343400920,Ardia
+1343400927,Jobias
+1343400934,Chiefo
+1343400947,Raphouko
+1343400950,Grauda
+1343401646,Harry Hellfire
+1343401883,Kachow
+1343401915,Margulis
+1343401948,Ta Trades
+1343402086,Black Emulio
+1343402091,Senior Emulio
+1343402094,Arkanen
+1343402172,Fuscion
+1343402437,Ta Bowyer
+1343402617,Mulio Miguel
+1343402794,Arco de Velocidad
+1343403194,Jackarse
+1343403281,Valerienpk
+1343403403,Emulio Levar
+1343403699,Ta Mule
+1343403801,Enmos
+1343403831,Irregardless
+1343404337,Emulio Rupert
+1343405624,Suffinmcholdins
+1343405723,Cheezbox
+1343405787,Cheesebox
+1343407228,Ugglymcmulez
+1343407536,Wrecktumologist
+1343408249,Aphira
+1343409552,Deadbobpeaseller
+1343410195,Girlmulei
+1343410198,Margulia
+1343410199,Fuscianna
+1343410201,Skullsberg
+1343410202,Shadowbutt
+1343411785,Quick Storage
+1343413051,Coors III
+1343413463,Amanah
+1343413987,Mediocre Ian
+1343414018,Ian the Intrepid
+1343414166,Lugian Steel
+1343414683,Gottem
+1343414695,Xoatl
+1343415063,Sylvera
+1343415253,Heavyset
+1343415326,Shalukah
+1343415658,Jhoa
+1343415664,Logicoma
+1343415837,Coors Odd and Ends
+1343416666,Aurior
+1343416702,Amanah's Mule
+1343416801,Coors Melee Weapons
+1343416930,Coors Missile Weapons
+1343417554,Cornmealius
+1343417866,Magus the Dark
+1343418124,Algorab
+1343419244,That Running Game
+1343419380,Dirty Storage
+1343420997,Coors Aetheria
+1343422848,Meow'
+1343423573,Underwear
+1343424422,High-Voltage
+1343424790,Silver Creek
+1343425235,Carrying Gold
+1343425406,Creek's Set Pieces
+1343425578,Brambles
+1343425850,Narcotic Reborn
+1343426152,Wilson Wilson
+1343426173,Whatcha Say
+1343426610,Fantastic Bowjob
+1343427748,Coors Rings IV
+1343428168,Deran Dark
+1343429037,Castorio
+1343429130,Daas Boot
+1343430150,Lanellesa
+1343430166,High-Voltage II
+1343430260,Sixty-Four Bit
+1343430275,Squishspielzeug
+1343430971,Crafterella
+1343430981,Muleon De Stuffas
+1343431713,Casterella
+1343431859,Destin
+1343434883,Town Crier's Liar
+1343437582,Coors Consumables
+1343440278,Jon Snow DiEs
+1343445347,Copastetic
+1343455275,High-Voltage's Locksmith
+1343455276,High-Voltage's Locksmith II
+1343455277,High-Voltage's Locksmith III
+1343455279,High-Voltage's Locksmith IV
+1343457995,Veganeesta
+1343457996,Miss Laggy Pants
+1343457999,Hosh Hosh
+1343459924,Zech
+1343460562,Zechron
+1343461877,Simgear Tinker
+1343463329,Wight Blade
+1343464366,Gmo LaBeling Required
+1343464552,Fquick Mule
+1343466570,Svet
+1343467140,Svet mule
+1343467144,Svet-li
+1343467178,Svet-load
+1343467573,Svet-tink
+1343467582,Svet-tinkk
+1343467584,Kseniaa
+1343467587,Sahri
+1343467605,Load-di
+1343467986,Ksen-load
+1343468016,Svet-load-one
+1343468205,Svet-load-letters
+1343468718,Sahri-load
+1343469846,Svet-load-two
+1343470767,Svet-Letters
+1343472814,Soquelo
+1343473847,El Burro Basura
+1343474423,Callaway's Salvage Mule
+1343475270,Soquel's Trade Mule
+1343475791,Helena of Borg
+1343475804,Victor of Borg
+1343479509,High-Voltage's Rare Farmer
+1343483277,Xander'
+1343484099,Miskelan
+1343484229,High-Voltage's Shopping Cart
+1343484283,Justyan
+1343486112,Miyu Rei
+1343486131,Kunari of Lin
+1343487898,Fgsdf
+1343487988,Rob The Hand
+1343488024,Brexit
+1343488764,Kama Koze
+1343489461,Krystira
+1343489517,Mageness
+1343489699,Zech Melee
+1343489702,Zech Tinker
+1343489706,Zech Mule
+1343490247,Vaciante
+1343490411,Ud Tinker
+1343490414,Bremmen
+1343490478,High-Voltage's Rare Farmer II
+1343491008,Zay the Magnificent
+1343491108,We Pwn Khao's
+1343491243,Mule Rox
+1343491246,High-Voltage's Banker II
+1343491247,High-Voltage's Locksmith V
+1343491459,Lootus of Borg
+1343491647,Farmerfran
+1343492054,Dota
+1343492135,Hold DeZ For Me
+1343492494,Mule Rox I
+1343492694,Accepting Donations
+1343492795,Dota II
+1343492818,Starwars
+1343492993,The End is Upon Us
+1343493040,Peace Mezzir-Garrett
+1343493042,Swashbuler
+1343493286,El Snert
+1343493320,Dota III
+1343493337,Pcaping the World
+1343493338,The Dutch Master
+1343493339,The End is Coming
+1343493341,Dota IV
+1343493342,Zarmm
+1343493346,Gabriella Jink
+1343493351,Dota V
+1343493389,Mule Roxii
+1343493390,Mule Rox III
+1343493391,Mule Rox IV
+1343493392,Mule Rox V
+1343493393,Mule Rox VI
+1343493395,Mule Rox VII
+1343493397,Mule Rox VIII
+1343493398,Mule Rox VIIII
+1343493412,Raxem
+1343493428,Hold More
+1343493432,Dark Mazur
+1343493435,Dark Noble Malzar
+1343493436,Dark Malzar
+1343493441,Dota VI
+1343493453,Jak end
+1343493543,Diddly Squat
+1343493571,Dota VII
+1343493601,Liam Neeson
+1343493612,Krystana
+1343493635,Last Breath'
+1343493763,Raistln
+1343493791,Asoph
+1343493796,Dataman-Warmage
+1343493904,Emberlaine
+1343493933,Sklerp
+1343493936,Amanah Dw
+1343493953,Ash Gromnies
+1343493987,Llac Norehsa
+1343494006,Jakthoi
+1343494011,Kiss Me I'm Gay
+1343494013,Testacemu
+1343494019,Surloshen
+1343494020,Dardante
+1343494025,Mosswart Fort Leader
+1343494027,Stackoverflows
+1343494030,Mosswart Fort Conqueror
+1343494083,Free salvage
+1343494089,Shadow Log
+1343494097,I Hide Stuff In My Butt
+1343494098,Heavy Weapon
+1343494099,Missile Weapon
+1343494110,Crithaya
+1343494129,Legendary Armors
+1343494132,Tuoshaixi
+1343494134,Vanarthus
+1343494135,Dskdan
+1343494138,The Olthoi Covenant
+1343494139,Legendary Set Armor
+1343494140,Legendary Rings
+1343494152,Crabbattle
+1343494203,Solitary'
+1343494240,Wb Executive
+1343494241,Severlin'
+1343494267,The End is Here
+1343494308,Sabina Pasic
+1343494309,Jody Smith
+1343494310,Liz Bouiss
+1343494311,Laura Cristina Herrera
+1343494312,Virginia Theresa Herrera
+1343494316,Packetgimp
+1343494337,Undead Camp King
+1343503153,Newbies Wit Attitude
+1343504351,Black Wish
+1343509277,Spotieodiedopalicous
+1343514752,Tidesroar
+1343523896,T'H'E D'A'R'K O'N'E
+1343533150,Gov
+1343535071,Rage of the Darkness
+1343556164,Ash Gromnies
+1343561630,Baeth Elgolhuir'Bulkur
+1343587494,Deebo'
+1343593571,The Dark Decending
+1343597638,Deathsquire
+1343627022,Zero hour
+1343636809,Bremmen of Itb
+1343640451,Maynard James Keenan
+1343640454,Spartan-Atlas
+1343640456,A Blacksmith
+1343664605,Dread Trogdor
+1343670165,Mange Lange
+1343679586,Gagga Maggot
+1343687126,A A
+1343687845,Blood Sky
+1343687877,Salur al-Zaraf
+1343689531,Thomas the Cat
+1343690013,Egorian
+1343695474,Midnight The Dark
+1343695867,Say tan
+1343701764,Real killa
+1343715795,Anoob
+1343716955,Vk-mage
+1343717385,The Unknown'
+1343718571,Koma-xxx
+1343724266,Matrix'
+1343724703,A taste of cahos
+1343724717,A taste of chaos
+1343724834,Carry Dez
+1343725037,Nicca
+1343725554,Teabagged
+1343731748,Addraevan'
+1343731984,Alchy-Mist
+1343736701,Kamikaze Chick
+1343738773,Aastrella
+1343743514,Urahara
+1343777707,Razlam
+1343784593,I Pwn all Noobs
+1343789100,Scuba Smith
+1343789507,Fisherman Steve
+1343790308,The Scuba Squad
+1343790484,Omghealz
+1343803904,Genese
+1343804590,Congo Natty
+1343804678,Under attack
+1343807209,Bag pack Storage
+1343809061,Enemy spoted
+1343810636,Bag Back Storage I
+1343812638,Bag Pack Di
+1343815589,Maxmagicdefense
+1343832053,Ya Dig
+1343836416,Arkaina
+1343837035,Xcxcxcx
+1343837036,Fgfgf
+1343837037,Fdgvcb
+1343837038,Vcbvbcv
+1343837039,Bvnvbnvb
+1343837040,Cvxcvxcvx
+1343837041,Dfgdfgdfcvbcv
+1343837042,Dghfhftg
+1343837043,Zxczxczx
+1343837044,Czxczxcz
+1343837045,Cxzczxcz
+1343838080,Gnostic Mag
+1343846586,Lost Goods
+1343879484,Farfinugen
+1343879488,Shibble Pip McPickle
+1343880489,Baeth Le Farfadet
+1343881666,Genese Dread Wish
+1343881667,Genese dreadagger
+1343881940,Esprit Des Bannis
+1343883940,Crazy Hands
+1343885388,Le Porteur
+1343890284,R and S
+1343890285,Porteur d'Alchemiste
+1343890286,Weap Boy
+1343890287,Armurier
+1343892016,Mr Fz
+1343892344,Le S and R
+1343892602,Psychosomatic
+1343892884,Khapa L'Aztec
+1343893389,Deran Darkness
+1343894174,Drowzee
+1343895202,I Test Portals
+1343895285,Kiss me I'm Gay
+1343902738,House Storage
+1343902964,Woow
+1343903524,Copyright Vk and Co
+1343903527,Swindler Barter
+1343903528,Long Shot n Wands
+1343903529,Short Shot et Melee
+1343903530,L'Imbueur
+1343903582,Weapon Salvager
+1343903583,Armor Salvager
+1343904987,Deva Kali
+1343905155,Aztec Les Indigenes
+1343908343,Aabbcc
+1343909744,Kdjvsdkf
+1343914112,Ultraviolet
+1343915248,Yuygjhjgh
+1343919437,City of Egos
+1343920060,Iusidopasda
+1343921309,Lungbreaker
+1343924020,Graveler
+1343925786,Heijoshin
+1343933821,Marowak
+1343934712,Wielders
+1343937333,Imbuer Weapon Salvager
+1343937524,Shen Do's Treasures
+1343937960,Yougonnadie
+1343947076,Super Metroid
+1343949165,Hold it'
+1343953294,Bigbad
+1343953728,That Really Grinds My Gears
+1343954021,Magma Golem Exarch
+1343961371,Motor Mouth
+1343976740,Salvage Bia
+1343979427,Dsfsdfsf
+1343981330,Dt Assasin'
+1343981333,Ya digs alt
+1343981336,It dont matter
+1343981358,Gayness Maximus
+1343981784,Random Reroll
+1343983421,Phantom's Mule
+1343991339,Vertales
+1343991925,Lissitha
+1343992695,Vegan Cannibal
+1344009669,Whaaaaaa
+1344012948,Fackin Eh
+1344013931,Deuce Dropper
+1344016309,Short Bus Bully
+1344018063,Slug Bug
+1344018920,Gold Mule Bia
+1344019045,First Games of Childhood
+1344019054,Illuminating Void
+1344020363,Asea
+1344020399,Sao sin
+1344020891,Johan Franzen
+1344020911,Trench Coat Flasher
+1344022507,Hat-Trick
+1344023668,Cashmoneyallday
+1344023983,Moose Knuckles
+1344024061,Spank Bank
+1344026664,Shojin-ri
+1344027092,Beholdened
+1344027650,Cimerrrra
+1344028861,Kilaeioaf
+1344029443,Holdertt
+1344029550,Table
+1344032535,Selig
+1344032604,Owain
+1344032741,Olthoi Nobel
+1344032895,Kugos
+1344032969,Loddy
+1344036378,Srfgjsgjsryj
+1344036687,Hfjfghfgh
+1344036931,L'Ancien
+1344038118,Ogrok Soul Bender
+1344043043,Atlan Vahn Lunatic
+1344047889,Prepare Your Anus
+1344048207,Cheezbox
+1344048462,Muleguy I
+1344058711,Akal of the White Sands
+1344058954,Ill Profit
+1344058965,Breh
+1344058966,Lowki
+1344062633,Spirit person
+1344064847,Bloodtaster
+1344065414,La P'tite Flectchy
+1344067096,Sniksnork
+1344067099,Clisp
+1344072009,Violet Rain
+1344075614,Bowman Josephus
+1344077134,Big Lenny
+1344077141,Senor Chang
+1344077470,Ujiio
+1344081116,Bow of the Ancients
+1344081612,Kyyuzo
+1344085682,Hyjetyujtryjtryjrtyj
+1344111524,Pat p
+1344112350,Mark g
+1344112405,Worthington Foulfellow
+1344113248,Steve r
+1344116032,Russel o
+1344116523,Greg a
+1344125611,Phantom Sight
+1344137645,Art f
+1344148781,Meat Man Joe
+1344149639,Arwens
+1344149640,Bilbao
+1344149641,Cirano
+1344149642,Devos
+1344149643,Erwans
+1344149644,Fernandez
+1344149645,Guilerm
+1344149646,Herwans
+1344149647,Iszin
+1344149648,Jerloo
+1344149649,Keeboots
+1344151091,Ashly g
+1344151320,Milosa
+1344151330,Little person
+1344153705,Hulkster
+1344154915,Chad p
+1344156931,Sssaaalllvvvaaagggeee
+1344157996,Fdsfadsa
+1344161788,Imtrippin
+1344162601,El fedor
+1344162603,Kellyclarkson
+1344162604,Tinkmebaby
+1344162605,Taylorswift
+1344162606,Loubega
+1344163850,Blackjack Davey
+1344165297,Dumppp Offf Mule
+1344165329,Untinked Rare Death Items
+1344165449,Rare wand dis
+1344165552,Noob Night
+1344165568,Sallllllllllllllvage
+1344167606,Brass Me Life
+1344171851,Pull the Dicks out
+1344172022,I Carry On
+1344172046,Le Porteur d'Armures
+1344172074,Brokkr
+1344172147,Bone Dealer
+1344172148,Bone Supremacy
+1344172149,Bone Dreamer
+1344172491,Sindrii
+1344172632,Inti
+1344174358,Hlin
+1344174825,Gorzak
+1344174908,Dark Mazur
+1344174909,Raxem
+1344174910,Phare Well
+1344174931,Noob God
+1344174935,Rip Best Game Ever
+1344174949,Crabbattle
+1344174975,Killerwolf III
+1344174987,Grombly
+1344175005,Ripley of Frostfell
+1344175012,Zojak Quazith
+1344175017,Sloppy Giuseppe
+1344175034,Org of the Hill People
+1344175045,Blood Quench
+1344175055,Beep Beep Boop
+1344175059,Sloppy Giuseppe's Secret Sausage
+1344175062,Shorty the Eternal'
+1344175085,Zap Pa
+1344175102,Bodhisattva of the Sword
+1344175125,Lightfighter
+1344175138,Whoopsie Goldbug
+1344175155,Stunky Turdington
+1344175158,Luurch
+1344175164,Killerwolf II
+1344175170,Defeated defeated defeated
+1344175180,Olthoi Fuccboi
+1344175187,Killerwolf IV
+1344175197,Jakthoi
+1344175210,Dagryn Stabir
+1344175277,Theresa Herrera
+1344175292,Bhagevad Gita
+1344175293,Billy Herrington
+1344175294,Billy Herrington
+1344175305,Big D Boy
+1344175314,Faelicity
+1344175337,Bladeslinger'
+1344175340,Van Darkholme
+1344175354,Www Acemulator Org
+1344175389,Emulator In Progress
+1344175395,Anoobeer
+1344175396,Emulators
+1344175397,Charlie Murphy III
+1344175400,Your Mother II
+1344175401,Olthoirgreat
+1344175417,Droden Is A Giant Tawat
+1344175460,Malthus Thayer
+1344175465,Angie Kreynus
+1344175466,Isabel Umana
+1344175467,Crisinta Herrera
+1344175468,Heather Downey
+1344175469,Lisa Grace Cole
+1344175470,Elizabeth Bouiss
+1344175471,Jody Smith
+1344175472,Yasha Carpentier
+1344175473,Christina Herrera

--- a/aclogview/Properties/Settings.Designer.cs
+++ b/aclogview/Properties/Settings.Designer.cs
@@ -169,12 +169,60 @@ namespace aclogview.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string CreatureNameCombat {
+        public string CreatureNameCombat1 {
             get {
-                return ((string)(this["CreatureNameCombat"]));
+                return ((string)(this["CreatureNameCombat1"]));
             }
             set {
-                this["CreatureNameCombat"] = value;
+                this["CreatureNameCombat1"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CreatureNameCombat2 {
+            get {
+                return ((string)(this["CreatureNameCombat2"]));
+            }
+            set {
+                this["CreatureNameCombat2"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CreatureNameCombat3 {
+            get {
+                return ((string)(this["CreatureNameCombat3"]));
+            }
+            set {
+                this["CreatureNameCombat3"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CreatureNameCombat4 {
+            get {
+                return ((string)(this["CreatureNameCombat4"]));
+            }
+            set {
+                this["CreatureNameCombat4"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CreatureNameCombat5 {
+            get {
+                return ((string)(this["CreatureNameCombat5"]));
+            }
+            set {
+                this["CreatureNameCombat5"] = value;
             }
         }
     }

--- a/aclogview/Properties/Settings.Designer.cs
+++ b/aclogview/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace aclogview.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -163,6 +163,18 @@ namespace aclogview.Properties {
             }
             set {
                 this["ACEStyleHeaders"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CreatureNameCombat {
+            get {
+                return ((string)(this["CreatureNameCombat"]));
+            }
+            set {
+                this["CreatureNameCombat"] = value;
             }
         }
     }

--- a/aclogview/Properties/Settings.settings
+++ b/aclogview/Properties/Settings.settings
@@ -38,5 +38,8 @@
     <Setting Name="ACEStyleHeaders" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="CreatureNameCombat" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/aclogview/Properties/Settings.settings
+++ b/aclogview/Properties/Settings.settings
@@ -38,7 +38,19 @@
     <Setting Name="ACEStyleHeaders" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="CreatureNameCombat" Type="System.String" Scope="User">
+    <Setting Name="CreatureNameCombat1" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="CreatureNameCombat2" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="CreatureNameCombat3" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="CreatureNameCombat4" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="CreatureNameCombat5" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
   </Settings>

--- a/aclogview/Tools/CombatScraper.Designer.cs
+++ b/aclogview/Tools/CombatScraper.Designer.cs
@@ -49,16 +49,16 @@ namespace aclogview.Tools
             this.rdbMeleeDamage = new System.Windows.Forms.RadioButton();
             this.rdbMagicDamage = new System.Windows.Forms.RadioButton();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.tbCreatureName2 = new System.Windows.Forms.TextBox();
-            this.tbCreatureName3 = new System.Windows.Forms.TextBox();
-            this.tbCreatureName4 = new System.Windows.Forms.TextBox();
-            this.tbCreatureName5 = new System.Windows.Forms.TextBox();
-            this.chkExcludeNonRetailPcaps = new System.Windows.Forms.CheckBox();
-            this.label4 = new System.Windows.Forms.Label();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label6 = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
             this.label8 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.tbCreatureName5 = new System.Windows.Forms.TextBox();
+            this.tbCreatureName4 = new System.Windows.Forms.TextBox();
+            this.tbCreatureName3 = new System.Windows.Forms.TextBox();
+            this.tbCreatureName2 = new System.Windows.Forms.TextBox();
+            this.chkExcludeNonRetailPcaps = new System.Windows.Forms.CheckBox();
             this.label9 = new System.Windows.Forms.Label();
             this.statusStrip1.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -113,6 +113,10 @@ namespace aclogview.Tools
             this.tbOutputFolder.Name = "tbOutputFolder";
             this.tbOutputFolder.Size = new System.Drawing.Size(517, 20);
             this.tbOutputFolder.TabIndex = 5;
+            // 
+            // timer1
+            // 
+            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
             // 
             // btnChangeSearchPathRoot
             // 
@@ -236,72 +240,14 @@ namespace aclogview.Tools
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Creature Name";
             // 
-            // tbCreatureName2
+            // label8
             // 
-            this.tbCreatureName2.Location = new System.Drawing.Point(30, 78);
-            this.tbCreatureName2.Name = "tbCreatureName2";
-            this.tbCreatureName2.Size = new System.Drawing.Size(247, 20);
-            this.tbCreatureName2.TabIndex = 1;
-            // 
-            // tbCreatureName3
-            // 
-            this.tbCreatureName3.Location = new System.Drawing.Point(30, 104);
-            this.tbCreatureName3.Name = "tbCreatureName3";
-            this.tbCreatureName3.Size = new System.Drawing.Size(247, 20);
-            this.tbCreatureName3.TabIndex = 2;
-            // 
-            // tbCreatureName4
-            // 
-            this.tbCreatureName4.Location = new System.Drawing.Point(30, 130);
-            this.tbCreatureName4.Name = "tbCreatureName4";
-            this.tbCreatureName4.Size = new System.Drawing.Size(247, 20);
-            this.tbCreatureName4.TabIndex = 3;
-            // 
-            // tbCreatureName5
-            // 
-            this.tbCreatureName5.Location = new System.Drawing.Point(30, 156);
-            this.tbCreatureName5.Name = "tbCreatureName5";
-            this.tbCreatureName5.Size = new System.Drawing.Size(247, 20);
-            this.tbCreatureName5.TabIndex = 4;
-            // 
-            // chkExcludeNonRetailPcaps
-            // 
-            this.chkExcludeNonRetailPcaps.AutoSize = true;
-            this.chkExcludeNonRetailPcaps.Checked = true;
-            this.chkExcludeNonRetailPcaps.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(382, 100);
-            this.chkExcludeNonRetailPcaps.Name = "chkExcludeNonRetailPcaps";
-            this.chkExcludeNonRetailPcaps.Size = new System.Drawing.Size(150, 17);
-            this.chkExcludeNonRetailPcaps.TabIndex = 24;
-            this.chkExcludeNonRetailPcaps.Text = "Exclude Non-Retail Pcaps";
-            this.chkExcludeNonRetailPcaps.UseVisualStyleBackColor = true;
-            // 
-            // label4
-            // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(8, 55);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(16, 13);
-            this.label4.TabIndex = 5;
-            this.label4.Text = "1.";
-            // 
-            // label5
-            // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(8, 133);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(16, 13);
-            this.label5.TabIndex = 6;
-            this.label5.Text = "4.";
-            // 
-            // label6
-            // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(8, 159);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(16, 13);
-            this.label6.TabIndex = 7;
-            this.label6.Text = "5.";
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(8, 81);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(16, 13);
+            this.label8.TabIndex = 9;
+            this.label8.Text = "2.";
             // 
             // label7
             // 
@@ -312,14 +258,70 @@ namespace aclogview.Tools
             this.label7.TabIndex = 8;
             this.label7.Text = "3.";
             // 
-            // label8
+            // label6
             // 
-            this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(8, 81);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(16, 13);
-            this.label8.TabIndex = 9;
-            this.label8.Text = "2.";
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(8, 159);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(16, 13);
+            this.label6.TabIndex = 7;
+            this.label6.Text = "5.";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(8, 133);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(16, 13);
+            this.label5.TabIndex = 6;
+            this.label5.Text = "4.";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(8, 55);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(16, 13);
+            this.label4.TabIndex = 5;
+            this.label4.Text = "1.";
+            // 
+            // tbCreatureName5
+            // 
+            this.tbCreatureName5.Location = new System.Drawing.Point(30, 156);
+            this.tbCreatureName5.Name = "tbCreatureName5";
+            this.tbCreatureName5.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName5.TabIndex = 4;
+            // 
+            // tbCreatureName4
+            // 
+            this.tbCreatureName4.Location = new System.Drawing.Point(30, 130);
+            this.tbCreatureName4.Name = "tbCreatureName4";
+            this.tbCreatureName4.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName4.TabIndex = 3;
+            // 
+            // tbCreatureName3
+            // 
+            this.tbCreatureName3.Location = new System.Drawing.Point(30, 104);
+            this.tbCreatureName3.Name = "tbCreatureName3";
+            this.tbCreatureName3.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName3.TabIndex = 2;
+            // 
+            // tbCreatureName2
+            // 
+            this.tbCreatureName2.Location = new System.Drawing.Point(30, 78);
+            this.tbCreatureName2.Name = "tbCreatureName2";
+            this.tbCreatureName2.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName2.TabIndex = 1;
+            // 
+            // chkExcludeNonRetailPcaps
+            // 
+            this.chkExcludeNonRetailPcaps.AutoSize = true;
+            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(382, 100);
+            this.chkExcludeNonRetailPcaps.Name = "chkExcludeNonRetailPcaps";
+            this.chkExcludeNonRetailPcaps.Size = new System.Drawing.Size(150, 17);
+            this.chkExcludeNonRetailPcaps.TabIndex = 24;
+            this.chkExcludeNonRetailPcaps.Text = "Exclude Non-Retail Pcaps";
+            this.chkExcludeNonRetailPcaps.UseVisualStyleBackColor = true;
             // 
             // label9
             // 

--- a/aclogview/Tools/CombatScraper.Designer.cs
+++ b/aclogview/Tools/CombatScraper.Designer.cs
@@ -60,6 +60,7 @@ namespace aclogview.Tools
             this.tbCreatureName2 = new System.Windows.Forms.TextBox();
             this.chkExcludeNonRetailPcaps = new System.Windows.Forms.CheckBox();
             this.label9 = new System.Windows.Forms.Label();
+            this.label10 = new System.Windows.Forms.Label();
             this.statusStrip1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
@@ -200,24 +201,27 @@ namespace aclogview.Tools
             // 
             this.rdbMeleeDamage.AutoSize = true;
             this.rdbMeleeDamage.Checked = true;
-            this.rdbMeleeDamage.Location = new System.Drawing.Point(326, 152);
+            this.rdbMeleeDamage.Enabled = false;
+            this.rdbMeleeDamage.Location = new System.Drawing.Point(326, 171);
             this.rdbMeleeDamage.Name = "rdbMeleeDamage";
             this.rdbMeleeDamage.Size = new System.Drawing.Size(133, 17);
             this.rdbMeleeDamage.TabIndex = 11;
             this.rdbMeleeDamage.TabStop = true;
             this.rdbMeleeDamage.Text = "Melee/Missile Damage";
             this.rdbMeleeDamage.UseVisualStyleBackColor = true;
+            this.rdbMeleeDamage.Visible = false;
             // 
             // rdbMagicDamage
             // 
             this.rdbMagicDamage.AutoSize = true;
             this.rdbMagicDamage.Enabled = false;
-            this.rdbMagicDamage.Location = new System.Drawing.Point(465, 151);
+            this.rdbMagicDamage.Location = new System.Drawing.Point(465, 170);
             this.rdbMagicDamage.Name = "rdbMagicDamage";
             this.rdbMagicDamage.Size = new System.Drawing.Size(97, 17);
             this.rdbMagicDamage.TabIndex = 12;
             this.rdbMagicDamage.Text = "Magic Damage";
             this.rdbMagicDamage.UseVisualStyleBackColor = true;
+            this.rdbMagicDamage.Visible = false;
             this.rdbMagicDamage.CheckedChanged += new System.EventHandler(this.rdbMagicDamage_CheckedChanged);
             // 
             // groupBox1
@@ -233,7 +237,7 @@ namespace aclogview.Tools
             this.groupBox1.Controls.Add(this.tbCreatureName2);
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Controls.Add(this.tbCreatureName1);
-            this.groupBox1.Location = new System.Drawing.Point(15, 126);
+            this.groupBox1.Location = new System.Drawing.Point(15, 151);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(294, 188);
             this.groupBox1.TabIndex = 13;
@@ -327,17 +331,30 @@ namespace aclogview.Tools
             // 
             this.label9.AutoSize = true;
             this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label9.Location = new System.Drawing.Point(388, 132);
+            this.label9.Location = new System.Drawing.Point(388, 151);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(96, 16);
             this.label9.TabIndex = 25;
             this.label9.Text = "DamageType:";
+            this.label9.Visible = false;
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label10.Location = new System.Drawing.Point(80, 129);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(448, 15);
+            this.label10.TabIndex = 26;
+            this.label10.Text = "This Scraper creates a csv file with both Magic and Melee/Missile Attack damage.";
+            this.label10.Click += new System.EventHandler(this.label10_Click);
             // 
             // CombatScraper
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(596, 450);
+            this.Controls.Add(this.label10);
             this.Controls.Add(this.label9);
             this.Controls.Add(this.chkExcludeNonRetailPcaps);
             this.Controls.Add(this.groupBox1);
@@ -354,7 +371,7 @@ namespace aclogview.Tools
             this.Controls.Add(this.btnStartScrape);
             this.Name = "CombatScraper";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "CombatScraper";
+            this.Text = "CombatScraper - Gets damage given to a creature from a player";
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
             this.groupBox1.ResumeLayout(false);
@@ -396,5 +413,6 @@ namespace aclogview.Tools
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.Label label10;
     }
 }

--- a/aclogview/Tools/CombatScraper.Designer.cs
+++ b/aclogview/Tools/CombatScraper.Designer.cs
@@ -64,8 +64,11 @@ namespace aclogview.Tools
             this.chkCharList = new System.Windows.Forms.CheckBox();
             this.tbFileNameDescription = new System.Windows.Forms.TextBox();
             this.label11 = new System.Windows.Forms.Label();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.chkExportCharsWeapons = new System.Windows.Forms.CheckBox();
             this.statusStrip1.SuspendLayout();
             this.groupBox1.SuspendLayout();
+            this.groupBox2.SuspendLayout();
             this.SuspendLayout();
             // 
             // label1
@@ -86,7 +89,7 @@ namespace aclogview.Tools
             // 
             // btnStartScrape
             // 
-            this.btnStartScrape.Location = new System.Drawing.Point(373, 388);
+            this.btnStartScrape.Location = new System.Drawing.Point(447, 391);
             this.btnStartScrape.Name = "btnStartScrape";
             this.btnStartScrape.Size = new System.Drawing.Size(103, 23);
             this.btnStartScrape.TabIndex = 2;
@@ -96,7 +99,7 @@ namespace aclogview.Tools
             // 
             // btnStopScrape
             // 
-            this.btnStopScrape.Location = new System.Drawing.Point(482, 388);
+            this.btnStopScrape.Location = new System.Drawing.Point(556, 391);
             this.btnStopScrape.Name = "btnStopScrape";
             this.btnStopScrape.Size = new System.Drawing.Size(102, 23);
             this.btnStopScrape.TabIndex = 3;
@@ -108,14 +111,14 @@ namespace aclogview.Tools
             // 
             this.tbSearchPathRoot.Location = new System.Drawing.Point(15, 25);
             this.tbSearchPathRoot.Name = "tbSearchPathRoot";
-            this.tbSearchPathRoot.Size = new System.Drawing.Size(517, 20);
+            this.tbSearchPathRoot.Size = new System.Drawing.Size(585, 20);
             this.tbSearchPathRoot.TabIndex = 4;
             // 
             // tbOutputFolder
             // 
             this.tbOutputFolder.Location = new System.Drawing.Point(15, 74);
             this.tbOutputFolder.Name = "tbOutputFolder";
-            this.tbOutputFolder.Size = new System.Drawing.Size(517, 20);
+            this.tbOutputFolder.Size = new System.Drawing.Size(585, 20);
             this.tbOutputFolder.TabIndex = 5;
             // 
             // timer1
@@ -124,7 +127,7 @@ namespace aclogview.Tools
             // 
             // btnChangeSearchPathRoot
             // 
-            this.btnChangeSearchPathRoot.Location = new System.Drawing.Point(538, 25);
+            this.btnChangeSearchPathRoot.Location = new System.Drawing.Point(612, 25);
             this.btnChangeSearchPathRoot.Name = "btnChangeSearchPathRoot";
             this.btnChangeSearchPathRoot.Size = new System.Drawing.Size(46, 23);
             this.btnChangeSearchPathRoot.TabIndex = 6;
@@ -152,7 +155,7 @@ namespace aclogview.Tools
             // 
             // btnChangeOutputFolder
             // 
-            this.btnChangeOutputFolder.Location = new System.Drawing.Point(539, 70);
+            this.btnChangeOutputFolder.Location = new System.Drawing.Point(612, 74);
             this.btnChangeOutputFolder.Name = "btnChangeOutputFolder";
             this.btnChangeOutputFolder.Size = new System.Drawing.Size(45, 23);
             this.btnChangeOutputFolder.TabIndex = 7;
@@ -169,7 +172,7 @@ namespace aclogview.Tools
             this.toolStripStatusLabel3});
             this.statusStrip1.Location = new System.Drawing.Point(0, 428);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(596, 22);
+            this.statusStrip1.Size = new System.Drawing.Size(670, 22);
             this.statusStrip1.TabIndex = 10;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -205,7 +208,7 @@ namespace aclogview.Tools
             this.rdbMeleeDamage.AutoSize = true;
             this.rdbMeleeDamage.Checked = true;
             this.rdbMeleeDamage.Enabled = false;
-            this.rdbMeleeDamage.Location = new System.Drawing.Point(326, 171);
+            this.rdbMeleeDamage.Location = new System.Drawing.Point(122, 391);
             this.rdbMeleeDamage.Name = "rdbMeleeDamage";
             this.rdbMeleeDamage.Size = new System.Drawing.Size(133, 17);
             this.rdbMeleeDamage.TabIndex = 11;
@@ -218,7 +221,7 @@ namespace aclogview.Tools
             // 
             this.rdbMagicDamage.AutoSize = true;
             this.rdbMagicDamage.Enabled = false;
-            this.rdbMagicDamage.Location = new System.Drawing.Point(465, 170);
+            this.rdbMagicDamage.Location = new System.Drawing.Point(19, 391);
             this.rdbMagicDamage.Name = "rdbMagicDamage";
             this.rdbMagicDamage.Size = new System.Drawing.Size(97, 17);
             this.rdbMagicDamage.TabIndex = 12;
@@ -240,7 +243,7 @@ namespace aclogview.Tools
             this.groupBox1.Controls.Add(this.tbCreatureName2);
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Controls.Add(this.tbCreatureName1);
-            this.groupBox1.Location = new System.Drawing.Point(15, 151);
+            this.groupBox1.Location = new System.Drawing.Point(10, 151);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(294, 188);
             this.groupBox1.TabIndex = 13;
@@ -323,7 +326,9 @@ namespace aclogview.Tools
             // chkExcludeNonRetailPcaps
             // 
             this.chkExcludeNonRetailPcaps.AutoSize = true;
-            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(382, 100);
+            this.chkExcludeNonRetailPcaps.Checked = true;
+            this.chkExcludeNonRetailPcaps.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(9, 23);
             this.chkExcludeNonRetailPcaps.Name = "chkExcludeNonRetailPcaps";
             this.chkExcludeNonRetailPcaps.Size = new System.Drawing.Size(150, 17);
             this.chkExcludeNonRetailPcaps.TabIndex = 24;
@@ -334,11 +339,11 @@ namespace aclogview.Tools
             // 
             this.label9.AutoSize = true;
             this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label9.Location = new System.Drawing.Point(388, 151);
+            this.label9.Location = new System.Drawing.Point(93, 362);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(96, 16);
+            this.label9.Size = new System.Drawing.Size(54, 16);
             this.label9.TabIndex = 25;
-            this.label9.Text = "DamageType:";
+            this.label9.Text = "Options";
             this.label9.Visible = false;
             // 
             // label10
@@ -355,7 +360,9 @@ namespace aclogview.Tools
             // chkCharList
             // 
             this.chkCharList.AutoSize = true;
-            this.chkCharList.Location = new System.Drawing.Point(26, 346);
+            this.chkCharList.Checked = true;
+            this.chkCharList.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkCharList.Location = new System.Drawing.Point(9, 46);
             this.chkCharList.Name = "chkCharList";
             this.chkCharList.Size = new System.Drawing.Size(262, 17);
             this.chkCharList.TabIndex = 27;
@@ -364,7 +371,7 @@ namespace aclogview.Tools
             // 
             // tbFileNameDescription
             // 
-            this.tbFileNameDescription.Location = new System.Drawing.Point(15, 391);
+            this.tbFileNameDescription.Location = new System.Drawing.Point(6, 156);
             this.tbFileNameDescription.Name = "tbFileNameDescription";
             this.tbFileNameDescription.Size = new System.Drawing.Size(292, 20);
             this.tbFileNameDescription.TabIndex = 28;
@@ -372,23 +379,47 @@ namespace aclogview.Tools
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(12, 375);
+            this.label11.Location = new System.Drawing.Point(6, 137);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(288, 13);
             this.label11.TabIndex = 29;
             this.label11.Text = "File Name Description: (if blank, creature name will be used)";
             // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.chkExportCharsWeapons);
+            this.groupBox2.Controls.Add(this.label11);
+            this.groupBox2.Controls.Add(this.chkCharList);
+            this.groupBox2.Controls.Add(this.chkExcludeNonRetailPcaps);
+            this.groupBox2.Controls.Add(this.tbFileNameDescription);
+            this.groupBox2.Location = new System.Drawing.Point(332, 151);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(314, 188);
+            this.groupBox2.TabIndex = 30;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Options";
+            this.groupBox2.Enter += new System.EventHandler(this.groupBox2_Enter);
+            // 
+            // chkExportCharsWeapons
+            // 
+            this.chkExportCharsWeapons.AutoSize = true;
+            this.chkExportCharsWeapons.Checked = true;
+            this.chkExportCharsWeapons.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkExportCharsWeapons.Location = new System.Drawing.Point(9, 69);
+            this.chkExportCharsWeapons.Name = "chkExportCharsWeapons";
+            this.chkExportCharsWeapons.Size = new System.Drawing.Size(237, 17);
+            this.chkExportCharsWeapons.TabIndex = 28;
+            this.chkExportCharsWeapons.Text = "Export Characters and Weapons to Weenies";
+            this.chkExportCharsWeapons.UseVisualStyleBackColor = true;
+            // 
             // CombatScraper
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(596, 450);
-            this.Controls.Add(this.label11);
-            this.Controls.Add(this.tbFileNameDescription);
-            this.Controls.Add(this.chkCharList);
+            this.ClientSize = new System.Drawing.Size(670, 450);
+            this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.label10);
             this.Controls.Add(this.label9);
-            this.Controls.Add(this.chkExcludeNonRetailPcaps);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.rdbMagicDamage);
             this.Controls.Add(this.rdbMeleeDamage);
@@ -408,6 +439,8 @@ namespace aclogview.Tools
             this.statusStrip1.PerformLayout();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -449,5 +482,7 @@ namespace aclogview.Tools
         private System.Windows.Forms.CheckBox chkCharList;
         private System.Windows.Forms.TextBox tbFileNameDescription;
         private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.CheckBox chkExportCharsWeapons;
     }
 }

--- a/aclogview/Tools/CombatScraper.Designer.cs
+++ b/aclogview/Tools/CombatScraper.Designer.cs
@@ -350,7 +350,7 @@ namespace aclogview.Tools
             // 
             this.label10.AutoSize = true;
             this.label10.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label10.Location = new System.Drawing.Point(80, 129);
+            this.label10.Location = new System.Drawing.Point(80, 126);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(448, 15);
             this.label10.TabIndex = 26;

--- a/aclogview/Tools/CombatScraper.Designer.cs
+++ b/aclogview/Tools/CombatScraper.Designer.cs
@@ -61,6 +61,9 @@ namespace aclogview.Tools
             this.chkExcludeNonRetailPcaps = new System.Windows.Forms.CheckBox();
             this.label9 = new System.Windows.Forms.Label();
             this.label10 = new System.Windows.Forms.Label();
+            this.chkCharList = new System.Windows.Forms.CheckBox();
+            this.tbFileNameDescription = new System.Windows.Forms.TextBox();
+            this.label11 = new System.Windows.Forms.Label();
             this.statusStrip1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
@@ -83,7 +86,7 @@ namespace aclogview.Tools
             // 
             // btnStartScrape
             // 
-            this.btnStartScrape.Location = new System.Drawing.Point(373, 378);
+            this.btnStartScrape.Location = new System.Drawing.Point(373, 388);
             this.btnStartScrape.Name = "btnStartScrape";
             this.btnStartScrape.Size = new System.Drawing.Size(103, 23);
             this.btnStartScrape.TabIndex = 2;
@@ -93,7 +96,7 @@ namespace aclogview.Tools
             // 
             // btnStopScrape
             // 
-            this.btnStopScrape.Location = new System.Drawing.Point(482, 378);
+            this.btnStopScrape.Location = new System.Drawing.Point(482, 388);
             this.btnStopScrape.Name = "btnStopScrape";
             this.btnStopScrape.Size = new System.Drawing.Size(102, 23);
             this.btnStopScrape.TabIndex = 3;
@@ -349,11 +352,40 @@ namespace aclogview.Tools
             this.label10.Text = "This Scraper creates a csv file with both Magic and Melee/Missile Attack damage.";
             this.label10.Click += new System.EventHandler(this.label10_Click);
             // 
+            // chkCharList
+            // 
+            this.chkCharList.AutoSize = true;
+            this.chkCharList.Location = new System.Drawing.Point(26, 346);
+            this.chkCharList.Name = "chkCharList";
+            this.chkCharList.Size = new System.Drawing.Size(262, 17);
+            this.chkCharList.TabIndex = 27;
+            this.chkCharList.Text = "Use Character List (pre compiled list of characters)";
+            this.chkCharList.UseVisualStyleBackColor = true;
+            // 
+            // tbFileNameDescription
+            // 
+            this.tbFileNameDescription.Location = new System.Drawing.Point(15, 391);
+            this.tbFileNameDescription.Name = "tbFileNameDescription";
+            this.tbFileNameDescription.Size = new System.Drawing.Size(292, 20);
+            this.tbFileNameDescription.TabIndex = 28;
+            // 
+            // label11
+            // 
+            this.label11.AutoSize = true;
+            this.label11.Location = new System.Drawing.Point(12, 375);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(288, 13);
+            this.label11.TabIndex = 29;
+            this.label11.Text = "File Name Description: (if blank, creature name will be used)";
+            // 
             // CombatScraper
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(596, 450);
+            this.Controls.Add(this.label11);
+            this.Controls.Add(this.tbFileNameDescription);
+            this.Controls.Add(this.chkCharList);
             this.Controls.Add(this.label10);
             this.Controls.Add(this.label9);
             this.Controls.Add(this.chkExcludeNonRetailPcaps);
@@ -414,5 +446,8 @@ namespace aclogview.Tools
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label9;
         private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.CheckBox chkCharList;
+        private System.Windows.Forms.TextBox tbFileNameDescription;
+        private System.Windows.Forms.Label label11;
     }
 }

--- a/aclogview/Tools/CombatScraper.Designer.cs
+++ b/aclogview/Tools/CombatScraper.Designer.cs
@@ -1,0 +1,398 @@
+
+namespace aclogview.Tools
+{
+    partial class CombatScraper
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.label1 = new System.Windows.Forms.Label();
+            this.tbCreatureName1 = new System.Windows.Forms.TextBox();
+            this.btnStartScrape = new System.Windows.Forms.Button();
+            this.btnStopScrape = new System.Windows.Forms.Button();
+            this.tbSearchPathRoot = new System.Windows.Forms.TextBox();
+            this.tbOutputFolder = new System.Windows.Forms.TextBox();
+            this.timer1 = new System.Windows.Forms.Timer(this.components);
+            this.btnChangeSearchPathRoot = new System.Windows.Forms.Button();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.btnChangeOutputFolder = new System.Windows.Forms.Button();
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.toolStripStatusLabel4 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel2 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabel3 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.rdbMeleeDamage = new System.Windows.Forms.RadioButton();
+            this.rdbMagicDamage = new System.Windows.Forms.RadioButton();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.tbCreatureName2 = new System.Windows.Forms.TextBox();
+            this.tbCreatureName3 = new System.Windows.Forms.TextBox();
+            this.tbCreatureName4 = new System.Windows.Forms.TextBox();
+            this.tbCreatureName5 = new System.Windows.Forms.TextBox();
+            this.chkExcludeNonRetailPcaps = new System.Windows.Forms.CheckBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label8 = new System.Windows.Forms.Label();
+            this.label9 = new System.Windows.Forms.Label();
+            this.statusStrip1.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(6, 23);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(279, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Up to 5 Creatures. (leave others blank if using less than 5)";
+            // 
+            // tbCreatureName1
+            // 
+            this.tbCreatureName1.Location = new System.Drawing.Point(30, 52);
+            this.tbCreatureName1.Name = "tbCreatureName1";
+            this.tbCreatureName1.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName1.TabIndex = 0;
+            // 
+            // btnStartScrape
+            // 
+            this.btnStartScrape.Location = new System.Drawing.Point(373, 378);
+            this.btnStartScrape.Name = "btnStartScrape";
+            this.btnStartScrape.Size = new System.Drawing.Size(103, 23);
+            this.btnStartScrape.TabIndex = 2;
+            this.btnStartScrape.Text = "Start Scrape";
+            this.btnStartScrape.UseVisualStyleBackColor = true;
+            this.btnStartScrape.Click += new System.EventHandler(this.btnStartScrape_Click);
+            // 
+            // btnStopScrape
+            // 
+            this.btnStopScrape.Location = new System.Drawing.Point(482, 378);
+            this.btnStopScrape.Name = "btnStopScrape";
+            this.btnStopScrape.Size = new System.Drawing.Size(102, 23);
+            this.btnStopScrape.TabIndex = 3;
+            this.btnStopScrape.Text = "Stop Scrape";
+            this.btnStopScrape.UseVisualStyleBackColor = true;
+            this.btnStopScrape.Click += new System.EventHandler(this.btnStopScrape_Click);
+            // 
+            // tbSearchPathRoot
+            // 
+            this.tbSearchPathRoot.Location = new System.Drawing.Point(15, 25);
+            this.tbSearchPathRoot.Name = "tbSearchPathRoot";
+            this.tbSearchPathRoot.Size = new System.Drawing.Size(517, 20);
+            this.tbSearchPathRoot.TabIndex = 4;
+            // 
+            // tbOutputFolder
+            // 
+            this.tbOutputFolder.Location = new System.Drawing.Point(15, 74);
+            this.tbOutputFolder.Name = "tbOutputFolder";
+            this.tbOutputFolder.Size = new System.Drawing.Size(517, 20);
+            this.tbOutputFolder.TabIndex = 5;
+            // 
+            // btnChangeSearchPathRoot
+            // 
+            this.btnChangeSearchPathRoot.Location = new System.Drawing.Point(538, 25);
+            this.btnChangeSearchPathRoot.Name = "btnChangeSearchPathRoot";
+            this.btnChangeSearchPathRoot.Size = new System.Drawing.Size(46, 23);
+            this.btnChangeSearchPathRoot.TabIndex = 6;
+            this.btnChangeSearchPathRoot.Text = "Folder";
+            this.btnChangeSearchPathRoot.UseVisualStyleBackColor = true;
+            this.btnChangeSearchPathRoot.Click += new System.EventHandler(this.btnChangeSearchPathRoot_Click);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 9);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(98, 13);
+            this.label2.TabIndex = 7;
+            this.label2.Text = "Scraper Root Path:";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(12, 58);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(74, 13);
+            this.label3.TabIndex = 8;
+            this.label3.Text = "Output Folder:";
+            // 
+            // btnChangeOutputFolder
+            // 
+            this.btnChangeOutputFolder.Location = new System.Drawing.Point(539, 70);
+            this.btnChangeOutputFolder.Name = "btnChangeOutputFolder";
+            this.btnChangeOutputFolder.Size = new System.Drawing.Size(45, 23);
+            this.btnChangeOutputFolder.TabIndex = 7;
+            this.btnChangeOutputFolder.Text = "Folder";
+            this.btnChangeOutputFolder.UseVisualStyleBackColor = true;
+            this.btnChangeOutputFolder.Click += new System.EventHandler(this.btnChangeOutputFolder_Click);
+            // 
+            // statusStrip1
+            // 
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripStatusLabel4,
+            this.toolStripStatusLabel1,
+            this.toolStripStatusLabel2,
+            this.toolStripStatusLabel3});
+            this.statusStrip1.Location = new System.Drawing.Point(0, 428);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(596, 22);
+            this.statusStrip1.TabIndex = 10;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // toolStripStatusLabel4
+            // 
+            this.toolStripStatusLabel4.Name = "toolStripStatusLabel4";
+            this.toolStripStatusLabel4.Size = new System.Drawing.Size(42, 17);
+            this.toolStripStatusLabel4.Text = "Status:";
+            // 
+            // toolStripStatusLabel1
+            // 
+            this.toolStripStatusLabel1.Margin = new System.Windows.Forms.Padding(20, 3, 0, 2);
+            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(89, 17);
+            this.toolStripStatusLabel1.Text = "Files Processed:";
+            // 
+            // toolStripStatusLabel2
+            // 
+            this.toolStripStatusLabel2.Margin = new System.Windows.Forms.Padding(20, 3, 0, 2);
+            this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
+            this.toolStripStatusLabel2.Size = new System.Drawing.Size(59, 17);
+            this.toolStripStatusLabel2.Text = "Total Hits:";
+            // 
+            // toolStripStatusLabel3
+            // 
+            this.toolStripStatusLabel3.Margin = new System.Windows.Forms.Padding(20, 3, 0, 2);
+            this.toolStripStatusLabel3.Name = "toolStripStatusLabel3";
+            this.toolStripStatusLabel3.Size = new System.Drawing.Size(116, 17);
+            this.toolStripStatusLabel3.Text = "Message Exceptions:";
+            // 
+            // rdbMeleeDamage
+            // 
+            this.rdbMeleeDamage.AutoSize = true;
+            this.rdbMeleeDamage.Checked = true;
+            this.rdbMeleeDamage.Location = new System.Drawing.Point(326, 152);
+            this.rdbMeleeDamage.Name = "rdbMeleeDamage";
+            this.rdbMeleeDamage.Size = new System.Drawing.Size(133, 17);
+            this.rdbMeleeDamage.TabIndex = 11;
+            this.rdbMeleeDamage.TabStop = true;
+            this.rdbMeleeDamage.Text = "Melee/Missile Damage";
+            this.rdbMeleeDamage.UseVisualStyleBackColor = true;
+            // 
+            // rdbMagicDamage
+            // 
+            this.rdbMagicDamage.AutoSize = true;
+            this.rdbMagicDamage.Enabled = false;
+            this.rdbMagicDamage.Location = new System.Drawing.Point(465, 151);
+            this.rdbMagicDamage.Name = "rdbMagicDamage";
+            this.rdbMagicDamage.Size = new System.Drawing.Size(97, 17);
+            this.rdbMagicDamage.TabIndex = 12;
+            this.rdbMagicDamage.Text = "Magic Damage";
+            this.rdbMagicDamage.UseVisualStyleBackColor = true;
+            this.rdbMagicDamage.CheckedChanged += new System.EventHandler(this.rdbMagicDamage_CheckedChanged);
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.label8);
+            this.groupBox1.Controls.Add(this.label7);
+            this.groupBox1.Controls.Add(this.label6);
+            this.groupBox1.Controls.Add(this.label5);
+            this.groupBox1.Controls.Add(this.label4);
+            this.groupBox1.Controls.Add(this.tbCreatureName5);
+            this.groupBox1.Controls.Add(this.tbCreatureName4);
+            this.groupBox1.Controls.Add(this.tbCreatureName3);
+            this.groupBox1.Controls.Add(this.tbCreatureName2);
+            this.groupBox1.Controls.Add(this.label1);
+            this.groupBox1.Controls.Add(this.tbCreatureName1);
+            this.groupBox1.Location = new System.Drawing.Point(15, 126);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(294, 188);
+            this.groupBox1.TabIndex = 13;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Creature Name";
+            // 
+            // tbCreatureName2
+            // 
+            this.tbCreatureName2.Location = new System.Drawing.Point(30, 78);
+            this.tbCreatureName2.Name = "tbCreatureName2";
+            this.tbCreatureName2.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName2.TabIndex = 1;
+            // 
+            // tbCreatureName3
+            // 
+            this.tbCreatureName3.Location = new System.Drawing.Point(30, 104);
+            this.tbCreatureName3.Name = "tbCreatureName3";
+            this.tbCreatureName3.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName3.TabIndex = 2;
+            // 
+            // tbCreatureName4
+            // 
+            this.tbCreatureName4.Location = new System.Drawing.Point(30, 130);
+            this.tbCreatureName4.Name = "tbCreatureName4";
+            this.tbCreatureName4.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName4.TabIndex = 3;
+            // 
+            // tbCreatureName5
+            // 
+            this.tbCreatureName5.Location = new System.Drawing.Point(30, 156);
+            this.tbCreatureName5.Name = "tbCreatureName5";
+            this.tbCreatureName5.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName5.TabIndex = 4;
+            // 
+            // chkExcludeNonRetailPcaps
+            // 
+            this.chkExcludeNonRetailPcaps.AutoSize = true;
+            this.chkExcludeNonRetailPcaps.Checked = true;
+            this.chkExcludeNonRetailPcaps.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(382, 100);
+            this.chkExcludeNonRetailPcaps.Name = "chkExcludeNonRetailPcaps";
+            this.chkExcludeNonRetailPcaps.Size = new System.Drawing.Size(150, 17);
+            this.chkExcludeNonRetailPcaps.TabIndex = 24;
+            this.chkExcludeNonRetailPcaps.Text = "Exclude Non-Retail Pcaps";
+            this.chkExcludeNonRetailPcaps.UseVisualStyleBackColor = true;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(8, 55);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(16, 13);
+            this.label4.TabIndex = 5;
+            this.label4.Text = "1.";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(8, 133);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(16, 13);
+            this.label5.TabIndex = 6;
+            this.label5.Text = "4.";
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(8, 159);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(16, 13);
+            this.label6.TabIndex = 7;
+            this.label6.Text = "5.";
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(8, 107);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(16, 13);
+            this.label7.TabIndex = 8;
+            this.label7.Text = "3.";
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(8, 81);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(16, 13);
+            this.label8.TabIndex = 9;
+            this.label8.Text = "2.";
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label9.Location = new System.Drawing.Point(388, 132);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(96, 16);
+            this.label9.TabIndex = 25;
+            this.label9.Text = "DamageType:";
+            // 
+            // CombatScraper
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(596, 450);
+            this.Controls.Add(this.label9);
+            this.Controls.Add(this.chkExcludeNonRetailPcaps);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.rdbMagicDamage);
+            this.Controls.Add(this.rdbMeleeDamage);
+            this.Controls.Add(this.statusStrip1);
+            this.Controls.Add(this.btnChangeOutputFolder);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.btnChangeSearchPathRoot);
+            this.Controls.Add(this.tbOutputFolder);
+            this.Controls.Add(this.tbSearchPathRoot);
+            this.Controls.Add(this.btnStopScrape);
+            this.Controls.Add(this.btnStartScrape);
+            this.Name = "CombatScraper";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "CombatScraper";
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox tbCreatureName1;
+        private System.Windows.Forms.Button btnStartScrape;
+        private System.Windows.Forms.Button btnStopScrape;
+        private System.Windows.Forms.TextBox tbSearchPathRoot;
+        private System.Windows.Forms.TextBox tbOutputFolder;
+        private System.Windows.Forms.Timer timer1;
+        private System.Windows.Forms.Button btnChangeSearchPathRoot;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Button btnChangeOutputFolder;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel4;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel2;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel3;
+        private System.Windows.Forms.RadioButton rdbMeleeDamage;
+        private System.Windows.Forms.RadioButton rdbMagicDamage;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.TextBox tbCreatureName5;
+        private System.Windows.Forms.TextBox tbCreatureName4;
+        private System.Windows.Forms.TextBox tbCreatureName3;
+        private System.Windows.Forms.TextBox tbCreatureName2;
+        private System.Windows.Forms.CheckBox chkExcludeNonRetailPcaps;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label9;
+    }
+}

--- a/aclogview/Tools/CombatScraper.cs
+++ b/aclogview/Tools/CombatScraper.cs
@@ -326,5 +326,10 @@ namespace aclogview.Tools
         {
 
         }
+
+        private void groupBox2_Enter(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/aclogview/Tools/CombatScraper.cs
+++ b/aclogview/Tools/CombatScraper.cs
@@ -288,5 +288,10 @@ namespace aclogview.Tools
         {
             UpdateToolStrip();
         }
+
+        private void label10_Click(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/aclogview/Tools/CombatScraper.cs
+++ b/aclogview/Tools/CombatScraper.cs
@@ -22,6 +22,8 @@ namespace aclogview.Tools
 
         private List<string> pcapFileNameList = new List<string>();
 
+        private HashSet<uint> wieldedItemIDs = new HashSet<uint>();
+
         StringBuilder scrapeResults = new StringBuilder();
 
         private int filesProcessed;
@@ -245,6 +247,7 @@ namespace aclogview.Tools
             if (results.hits > 0)
                 pcapFileNameList.Add(fileName);
 
+            wieldedItemIDs = results.wieldedItemIDs;
             // filesProcessed++;
 
             Interlocked.Increment(ref filesProcessed);
@@ -266,9 +269,20 @@ namespace aclogview.Tools
 
             // TODO:  Redo the way final csv file is put together.
 
-                try
+            //string scrapeResultsTemp = string.Join("\r\n", scrapeResults.ToArray());
+            string tempPcapFileNameList = string.Join("\r\n", pcapFileNameList.ToArray());
+
+            string combatHeader = $"Combat Damage Given to a creature from a player \r\n" +
+                $"CharName,Attack,WeaponName,DamageType,Damage,Creature,Critical\r\n";
+
+            string fileListHeader = "The follwing PCAP files contained combat with your creature search list:";
+
+            string fileToWrite = fileListHeader + "\r\n" + tempPcapFileNameList + "\r\n" + "\r\n" + combatHeader  + scrapeResults;
+            
+
+            try
                 {
-                    scraper.WriteOutput(tbOutputFolder.Text, pcapFileNameList + scrapeResults, fileNameHeading, ref writeOutputAborted);
+                    scraper.WriteOutput(tbOutputFolder.Text, fileToWrite, fileNameHeading, ref writeOutputAborted);
                 }
                 catch (Exception ex)
                 {

--- a/aclogview/Tools/CombatScraper.cs
+++ b/aclogview/Tools/CombatScraper.cs
@@ -119,6 +119,8 @@ namespace aclogview.Tools
 
         private void btnStartScrape_Click(object sender, EventArgs e)
         {
+            scrapeResults = "";
+
             if (tbCreatureName1.Text =="")
             {
                 MessageBox.Show("Creature Name is blank", "Warning!");
@@ -141,10 +143,6 @@ namespace aclogview.Tools
             // Scrape starts here
             try
             {
-                btnStartScrape.Enabled = false;
-
-                filesToProcess = ToolUtil.GetPcapsInFolder(tbSearchPathRoot.Text);
-
                 filesProcessed = 0;
                 totalHits = 0;
                 totalExceptions = 0;
@@ -152,6 +150,12 @@ namespace aclogview.Tools
                 writeOutputAborted = false;
                 searchCompleted = false;
 
+                toolStripStatusLabel4.Text = "Status: Getting File List, pleae wait...";
+                
+
+                btnStartScrape.Enabled = false;
+
+                filesToProcess = ToolUtil.GetPcapsInFolder(tbSearchPathRoot.Text);
 
                 UpdateToolStrip("Processing Files");
 
@@ -215,7 +219,7 @@ namespace aclogview.Tools
                 totalHits += results.hits;
                 totalExceptions += results.messageExceptions;
                 }
-            scrapeResults = results.combatInfo;
+            scrapeResults += results.combatInfo;
 
             filesProcessed++;
 

--- a/aclogview/Tools/CombatScraper.cs
+++ b/aclogview/Tools/CombatScraper.cs
@@ -20,6 +20,10 @@ namespace aclogview.Tools
         private List<string> filesToProcess = new List<string>();
         private List<string> creatureNames = new List<string>();
 
+        private List<string> pcapFileNameList = new List<string>();
+
+        StringBuilder scrapeResults = new StringBuilder();
+
         private int filesProcessed;
         private readonly Object resultsLockObject = new Object();
         private long totalHits;
@@ -27,9 +31,9 @@ namespace aclogview.Tools
         private bool searchAborted;
         private bool writeOutputAborted;
         private bool searchCompleted;
-        private string scrapeResults;
+        //private string scrapeResults;
         private string fileNameHeading;
-        private string pcapFileNameList = "Creature Hits are in the following PCAP Files:\r\n";
+        // private string pcapFileNameList = "Creature Hits are in the following PCAP Files:\r\n";
 
 
         bool useCharList = false;
@@ -124,9 +128,9 @@ namespace aclogview.Tools
 
         private void btnStartScrape_Click(object sender, EventArgs e)
         {
-            scrapeResults = "";
+            //scrapeResults = "";
             creatureNames.Clear();
-            pcapFileNameList = "Creature Hits are in the following PCAP Files:\r\n";
+            // pcapFileNameList = "Creature Hits are in the following PCAP Files:\r\n";
 
             useCharList = chkCharList.Checked;
 
@@ -204,7 +208,7 @@ namespace aclogview.Tools
             foreach (var currentFile in filesToProcess)
                 ProcessFile(currentFile);
 
-            WriteOutput(scrapeResults);
+            WriteOutput(scrapeResults.ToString());
         }
 
         private void ProcessFile(string fileName)
@@ -237,9 +241,9 @@ namespace aclogview.Tools
                 totalExceptions += results.messageExceptions;
                 }
 
-            scrapeResults += results.combatInfo;
+            scrapeResults.Append(results.combatInfo);
             if (results.hits > 0)
-                pcapFileNameList += fileName + "\r\n";
+                pcapFileNameList.Add(fileName);
 
             // filesProcessed++;
 
@@ -259,6 +263,8 @@ namespace aclogview.Tools
             var scraper = new CombatDamageGiven();
             if (writeOutputAborted || Disposing || IsDisposed)
                 return;
+
+            // TODO:  Redo the way final csv file is put together.
 
                 try
                 {

--- a/aclogview/Tools/CombatScraper.cs
+++ b/aclogview/Tools/CombatScraper.cs
@@ -29,6 +29,8 @@ namespace aclogview.Tools
         private bool searchCompleted;
         private string scrapeResults;
         private string fileNameHeading;
+        private string pcapFileNameList = "Creature Hits are in the following PCAP Files:\r\n";
+
 
         bool useCharList = false;
 
@@ -70,7 +72,7 @@ namespace aclogview.Tools
 
             using (FolderBrowserDialog openFolder = new FolderBrowserDialog())
             {
-                openFolder.SelectedPath = Settings.Default.FindOpcodeInFilesRoot;
+                openFolder.SelectedPath = tbSearchPathRoot.Text;
                 if (openFolder.ShowDialog() == DialogResult.OK)
                     tbSearchPathRoot.Text = openFolder.SelectedPath;
             }
@@ -80,7 +82,7 @@ namespace aclogview.Tools
         {
             using (FolderBrowserDialog openFolder = new FolderBrowserDialog())
             {
-                openFolder.SelectedPath = Settings.Default.FragDatFileOutputFolder;
+                openFolder.SelectedPath = tbOutputFolder.Text;
                 if (openFolder.ShowDialog() == DialogResult.OK)
                     tbOutputFolder.Text = openFolder.SelectedPath;
             }
@@ -124,6 +126,7 @@ namespace aclogview.Tools
         {
             scrapeResults = "";
             creatureNames.Clear();
+            pcapFileNameList = "Creature Hits are in the following PCAP Files:\r\n";
 
             useCharList = chkCharList.Checked;
 
@@ -235,6 +238,8 @@ namespace aclogview.Tools
                 }
 
             scrapeResults += results.combatInfo;
+            if (results.hits > 0)
+                pcapFileNameList += fileName + "\r\n";
 
             // filesProcessed++;
 
@@ -257,7 +262,7 @@ namespace aclogview.Tools
 
                 try
                 {
-                    scraper.WriteOutput(tbOutputFolder.Text, scrapeResults, fileNameHeading, ref writeOutputAborted);
+                    scraper.WriteOutput(tbOutputFolder.Text, pcapFileNameList + scrapeResults, fileNameHeading, ref writeOutputAborted);
                 }
                 catch (Exception ex)
                 {

--- a/aclogview/Tools/CombatScraper.cs
+++ b/aclogview/Tools/CombatScraper.cs
@@ -1,0 +1,279 @@
+using aclogview.Properties;
+using aclogview.Tools.Scrapers;
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace aclogview.Tools
+{
+    public partial class CombatScraper : Form
+    {
+
+        private List<string> filesToProcess = new List<string>();
+        private List<string> creatureNames = new List<string>();
+
+        private int filesProcessed;
+        private readonly Object resultsLockObject = new Object();
+        private long totalHits;
+        private int totalExceptions;
+        private bool searchAborted;
+        private bool writeOutputAborted;
+        private bool searchCompleted;
+        private string scrapeResults;
+        private string fileNameHeading;
+
+        public CombatScraper()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+
+            tbSearchPathRoot.Text = Settings.Default.FindOpcodeInFilesRoot;
+            tbOutputFolder.Text = Settings.Default.FragDatFileOutputFolder;
+            tbCreatureName1.Text = Settings.Default.CreatureNameCombat1;
+            tbCreatureName2.Text = Settings.Default.CreatureNameCombat2;
+            tbCreatureName3.Text = Settings.Default.CreatureNameCombat3;
+            tbCreatureName4.Text = Settings.Default.CreatureNameCombat4;
+            tbCreatureName5.Text = Settings.Default.CreatureNameCombat5;
+        }
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            searchAborted = true;
+            writeOutputAborted = true;
+
+            Settings.Default.FindOpcodeInFilesRoot = tbSearchPathRoot.Text;
+            Settings.Default.FragDatFileOutputFolder = tbOutputFolder.Text;
+            Settings.Default.CreatureNameCombat1 = tbCreatureName1.Text;
+            Settings.Default.CreatureNameCombat2 = tbCreatureName2.Text;
+            Settings.Default.CreatureNameCombat3 = tbCreatureName3.Text;
+            Settings.Default.CreatureNameCombat4 = tbCreatureName4.Text;
+            Settings.Default.CreatureNameCombat5 = tbCreatureName5.Text;
+
+            base.OnClosing(e);
+        }
+
+        private void btnChangeSearchPathRoot_Click(object sender, EventArgs e)
+        {
+
+            using (FolderBrowserDialog openFolder = new FolderBrowserDialog())
+            {
+                openFolder.SelectedPath = Settings.Default.FindOpcodeInFilesRoot;
+                if (openFolder.ShowDialog() == DialogResult.OK)
+                    tbSearchPathRoot.Text = openFolder.SelectedPath;
+            }
+        }
+
+        private void btnChangeOutputFolder_Click(object sender, EventArgs e)
+        {
+            using (FolderBrowserDialog openFolder = new FolderBrowserDialog())
+            {
+                openFolder.SelectedPath = Settings.Default.FragDatFileOutputFolder;
+                if (openFolder.ShowDialog() == DialogResult.OK)
+                    tbOutputFolder.Text = openFolder.SelectedPath;
+            }
+        }
+
+        private void btnStopScrape_Click(object sender, EventArgs e)
+        {
+            if (!searchCompleted)
+            {
+                if (!searchAborted && !writeOutputAborted)
+                {
+                    searchAborted = true;
+                    btnStopScrape.Text = "Stop Writing Output";
+                    return;
+                }
+
+                if (!writeOutputAborted)
+                {
+                    writeOutputAborted = true;
+                    btnStopScrape.Text = "Stopping Write Output";
+                    btnStopScrape.Enabled = false;
+                    return;
+                }
+            }
+
+            if (searchCompleted)
+            {
+                btnStopScrape.Text = "Stop Scrape";
+
+                timer1.Stop();
+
+                tbSearchPathRoot.Enabled = true;
+                btnChangeSearchPathRoot.Enabled = true;
+
+                btnStartScrape.Enabled = true;
+                btnStopScrape.Enabled = false;
+            }
+        }
+
+        private void btnStartScrape_Click(object sender, EventArgs e)
+        {
+            if (tbCreatureName1.Text =="")
+            {
+                MessageBox.Show("Creature Name is blank", "Warning!");
+                return;
+            }
+
+            if (tbCreatureName1.Text != "")
+                creatureNames.Add(tbCreatureName1.Text);
+            if (tbCreatureName2.Text != "")
+                creatureNames.Add(tbCreatureName2.Text);
+            if (tbCreatureName3.Text != "")
+                creatureNames.Add(tbCreatureName3.Text);
+            if (tbCreatureName4.Text != "")
+                creatureNames.Add(tbCreatureName4.Text);
+            if (tbCreatureName5.Text != "")
+                creatureNames.Add(tbCreatureName5.Text);
+
+            fileNameHeading = tbCreatureName1.Text.Split(' ')[0];
+
+            // Scrape starts here
+            try
+            {
+                btnStartScrape.Enabled = false;
+
+                filesToProcess = ToolUtil.GetPcapsInFolder(tbSearchPathRoot.Text);
+
+                filesProcessed = 0;
+                totalHits = 0;
+                totalExceptions = 0;
+                searchAborted = false;
+                writeOutputAborted = false;
+                searchCompleted = false;
+
+
+                UpdateToolStrip("Processing Files");
+
+                tbSearchPathRoot.Enabled = false;
+                btnChangeSearchPathRoot.Enabled = false;
+              
+                btnStopScrape.Enabled = true;
+                timer1.Start();
+
+                // Do the actual search here
+                DoSearch();
+
+                searchCompleted = true;
+
+                if (!Disposing && !IsDisposed)
+                    BeginInvoke((Action)(() => btnStopScrape_Click(null, null)));
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.ToString());
+
+                btnStopScrape_Click(null, null);
+            }
+
+        }
+
+        private void DoSearch()
+        {
+            foreach (var currentFile in filesToProcess)
+                ProcessFile(currentFile);
+
+            WriteOutput(scrapeResults);
+        }
+
+        private void ProcessFile(string fileName)
+        {
+            if (searchAborted || Disposing || IsDisposed)
+                return;
+
+            var records = PCapReader.LoadPcap(fileName, true, ref searchAborted, out _);
+
+            if (chkExcludeNonRetailPcaps.Checked)
+            {
+                if (records.Count > 0)
+                {
+                    var servers = ServerList.FindBy(records[0].ipHeader, records[0].isSend);
+
+                    if (servers.Count != 1 || !servers[0].IsRetail)
+                        return;
+                }
+            }
+
+            var scraper = new CombatDamageGiven();
+                if (searchAborted || Disposing || IsDisposed)
+                    return;
+
+            var results = scraper.ProcessFileRecords(fileName, records, creatureNames, ref searchAborted);
+
+                lock (resultsLockObject)
+                {
+                totalHits += results.hits;
+                totalExceptions += results.messageExceptions;
+                }
+            scrapeResults = results.combatInfo;
+
+            filesProcessed++;
+
+        }
+
+        private void WriteOutput(string scrapeResults)
+        {
+            if (writeOutputAborted || Disposing || IsDisposed)
+                return;
+
+            if (!Directory.Exists(tbOutputFolder.Text))
+                Directory.CreateDirectory(tbOutputFolder.Text);
+
+            UpdateToolStrip("Writing Output ...");
+
+            var scraper = new CombatDamageGiven();
+            if (writeOutputAborted || Disposing || IsDisposed)
+                return;
+
+                try
+                {
+                    scraper.WriteOutput(tbOutputFolder.Text, scrapeResults, fileNameHeading, ref writeOutputAborted);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(ex.ToString(), scraper.GetType().Name);
+                }
+
+            if (Disposing || IsDisposed)
+                return;
+
+            if (writeOutputAborted)
+                UpdateToolStrip("Writing Output Aborted");
+            else
+                UpdateToolStrip("Writing Output Complete");
+        }
+
+        private void timer1_Tick(object sender, EventArgs e)
+        {
+            UpdateToolStrip();
+        }
+
+        private void UpdateToolStrip(string status = null)
+        {
+            if (status != null)
+                toolStripStatusLabel4.Text = "Status: " + status;
+
+            toolStripStatusLabel1.Text = "Files Processed: " + filesProcessed.ToString("N0") + " of " + filesToProcess.Count.ToString("N0");
+
+            toolStripStatusLabel2.Text = "Total Hits: " + totalHits.ToString("N0");
+
+            toolStripStatusLabel3.Text = "Message Exceptions: " + totalExceptions.ToString("N0");
+        }
+
+        private void rdbMagicDamage_CheckedChanged(object sender, EventArgs e)
+        {
+            MessageBox.Show("Magic Damage is not supported currently.", "Warning!");
+            rdbMeleeDamage.Checked = true;
+        }
+    }
+}

--- a/aclogview/Tools/CombatScraper.cs
+++ b/aclogview/Tools/CombatScraper.cs
@@ -30,6 +30,8 @@ namespace aclogview.Tools
         private string scrapeResults;
         private string fileNameHeading;
 
+        bool useCharList = false;
+
         public CombatScraper()
         {
             InitializeComponent();
@@ -123,6 +125,8 @@ namespace aclogview.Tools
             scrapeResults = "";
             creatureNames.Clear();
 
+            useCharList = chkCharList.Checked;
+
             if (tbCreatureName1.Text =="")
             {
                 MessageBox.Show("Creature Name is blank", "Warning!");
@@ -140,7 +144,11 @@ namespace aclogview.Tools
             if (tbCreatureName5.Text != "")
                 creatureNames.Add(tbCreatureName5.Text);
 
-            fileNameHeading = tbCreatureName1.Text.Split(' ')[0];
+            // Beginning of File Name
+            fileNameHeading = tbCreatureName1.Text;
+            if (tbFileNameDescription.Text != "")
+                fileNameHeading = tbFileNameDescription.Text;
+            
 
             // Scrape starts here
             try
@@ -218,7 +226,7 @@ namespace aclogview.Tools
                 if (searchAborted || Disposing || IsDisposed)
                     return;
 
-            var results = scraper.ProcessFileRecords(fileName, records, creatureNames, ref searchAborted);
+            var results = scraper.ProcessFileRecords(fileName, records, creatureNames, ref useCharList, ref searchAborted);
 
                 lock (resultsLockObject)
                 {

--- a/aclogview/Tools/CombatScraper.resx
+++ b/aclogview/Tools/CombatScraper.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>104, 17</value>
+  </metadata>
+</root>

--- a/aclogview/Tools/CreatureName.Designer.cs
+++ b/aclogview/Tools/CreatureName.Designer.cs
@@ -71,6 +71,7 @@ namespace aclogview.Tools
             this.btnCancel.TabIndex = 2;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
             // CreatureName
             // 

--- a/aclogview/Tools/CreatureName.Designer.cs
+++ b/aclogview/Tools/CreatureName.Designer.cs
@@ -1,0 +1,99 @@
+﻿
+namespace aclogview.Tools
+{
+    partial class CreatureName
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.btnOK = new System.Windows.Forms.Button();
+            this.tbCreatureName = new System.Windows.Forms.TextBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // btnOK
+            // 
+            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btnOK.Location = new System.Drawing.Point(26, 82);
+            this.btnOK.Name = "btnOK";
+            this.btnOK.Size = new System.Drawing.Size(117, 23);
+            this.btnOK.TabIndex = 1;
+            this.btnOK.Text = "OK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // tbCreatureName
+            // 
+            this.tbCreatureName.Location = new System.Drawing.Point(26, 40);
+            this.tbCreatureName.Name = "tbCreatureName";
+            this.tbCreatureName.Size = new System.Drawing.Size(240, 20);
+            this.tbCreatureName.TabIndex = 0;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(23, 24);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(75, 13);
+            this.label1.TabIndex = 3;
+            this.label1.Text = "CreatureName";
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(149, 82);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(117, 23);
+            this.btnCancel.TabIndex = 2;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            // 
+            // CreatureName
+            // 
+            this.AcceptButton = this.btnOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(285, 134);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.tbCreatureName);
+            this.Controls.Add(this.btnOK);
+            this.Name = "CreatureName";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "CreatureName";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        private System.Windows.Forms.TextBox tbCreatureName;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button btnCancel;
+        internal System.Windows.Forms.Button btnOK;
+    }
+}

--- a/aclogview/Tools/CreatureName.cs
+++ b/aclogview/Tools/CreatureName.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace aclogview.Tools
+{
+    public partial class CreatureName : Form
+    {
+        public string creatureName { get; set; }
+        public CreatureName()
+        {
+            InitializeComponent();
+        }
+
+        private void btnOK_Click(object sender, EventArgs e)
+        {
+
+            if (tbCreatureName.Text =="")
+                MessageBox.Show("Creature Name is blank", "Warning!");
+            creatureName = tbCreatureName.Text;
+        }
+    }
+}

--- a/aclogview/Tools/CreatureName.cs
+++ b/aclogview/Tools/CreatureName.cs
@@ -37,5 +37,10 @@ namespace aclogview.Tools
             creatureName = tbCreatureName.Text;
             Settings.Default.CreatureNameCombat = tbCreatureName.Text;
         }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            
+        }
     }
 }

--- a/aclogview/Tools/CreatureName.cs
+++ b/aclogview/Tools/CreatureName.cs
@@ -1,3 +1,4 @@
+using aclogview.Properties;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -18,12 +19,23 @@ namespace aclogview.Tools
             InitializeComponent();
         }
 
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+
+            tbCreatureName.Text = Settings.Default.CreatureNameCombat;
+
+        }
+
+        // CreatureNameCombat
+
         private void btnOK_Click(object sender, EventArgs e)
         {
 
             if (tbCreatureName.Text =="")
                 MessageBox.Show("Creature Name is blank", "Warning!");
             creatureName = tbCreatureName.Text;
+            Settings.Default.CreatureNameCombat = tbCreatureName.Text;
         }
     }
 }

--- a/aclogview/Tools/CreatureName.cs
+++ b/aclogview/Tools/CreatureName.cs
@@ -23,7 +23,7 @@ namespace aclogview.Tools
         {
             base.OnLoad(e);
 
-            tbCreatureName.Text = Settings.Default.CreatureNameCombat;
+            tbCreatureName.Text = Settings.Default.CreatureNameCombat1;
 
         }
 
@@ -35,7 +35,7 @@ namespace aclogview.Tools
             if (tbCreatureName.Text =="")
                 MessageBox.Show("Creature Name is blank", "Warning!");
             creatureName = tbCreatureName.Text;
-            Settings.Default.CreatureNameCombat = tbCreatureName.Text;
+            Settings.Default.CreatureNameCombat1 = tbCreatureName.Text;
         }
 
         private void btnCancel_Click(object sender, EventArgs e)

--- a/aclogview/Tools/CreatureName.resx
+++ b/aclogview/Tools/CreatureName.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/aclogview/Tools/FindOpcodeInFilesForm.cs
+++ b/aclogview/Tools/FindOpcodeInFilesForm.cs
@@ -56,6 +56,7 @@ namespace aclogview.Tools
         {
             using (FolderBrowserDialog openFolder = new FolderBrowserDialog())
             {
+                openFolder.SelectedPath = txtSearchPathRoot.Text;
                 if (openFolder.ShowDialog() == DialogResult.OK)
                     txtSearchPathRoot.Text = openFolder.SelectedPath;
             }

--- a/aclogview/Tools/FindTextInFilesForm.cs
+++ b/aclogview/Tools/FindTextInFilesForm.cs
@@ -53,6 +53,7 @@ namespace aclogview.Tools
         {
             using (FolderBrowserDialog openFolder = new FolderBrowserDialog())
             {
+                openFolder.SelectedPath = txtSearchPathRoot.Text;
                 if (openFolder.ShowDialog() == DialogResult.OK)
                     txtSearchPathRoot.Text = openFolder.SelectedPath;
             }

--- a/aclogview/Tools/PcapScraperForm.Designer.cs
+++ b/aclogview/Tools/PcapScraperForm.Designer.cs
@@ -49,6 +49,8 @@ namespace aclogview.Tools
             this.columnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.chkExcludeNonRetailPcaps = new System.Windows.Forms.CheckBox();
+            this.tbCreatureName = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
             this.statusStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.SuspendLayout();
@@ -83,14 +85,14 @@ namespace aclogview.Tools
             // 
             this.toolStripStatusLabel2.Margin = new System.Windows.Forms.Padding(20, 3, 0, 2);
             this.toolStripStatusLabel2.Name = "toolStripStatusLabel2";
-            this.toolStripStatusLabel2.Size = new System.Drawing.Size(60, 17);
+            this.toolStripStatusLabel2.Size = new System.Drawing.Size(59, 17);
             this.toolStripStatusLabel2.Text = "Total Hits:";
             // 
             // toolStripStatusLabel3
             // 
             this.toolStripStatusLabel3.Margin = new System.Windows.Forms.Padding(20, 3, 0, 2);
             this.toolStripStatusLabel3.Name = "toolStripStatusLabel3";
-            this.toolStripStatusLabel3.Size = new System.Drawing.Size(115, 17);
+            this.toolStripStatusLabel3.Size = new System.Drawing.Size(116, 17);
             this.toolStripStatusLabel3.Text = "Message Exceptions:";
             // 
             // btnChangeSearchPathRoot
@@ -108,7 +110,7 @@ namespace aclogview.Tools
             // 
             this.btnStopSearch.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnStopSearch.Enabled = false;
-            this.btnStopSearch.Location = new System.Drawing.Point(651, 81);
+            this.btnStopSearch.Location = new System.Drawing.Point(651, 105);
             this.btnStopSearch.Name = "btnStopSearch";
             this.btnStopSearch.Size = new System.Drawing.Size(121, 23);
             this.btnStopSearch.TabIndex = 12;
@@ -119,7 +121,7 @@ namespace aclogview.Tools
             // btnStartSearch
             // 
             this.btnStartSearch.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnStartSearch.Location = new System.Drawing.Point(524, 81);
+            this.btnStartSearch.Location = new System.Drawing.Point(524, 105);
             this.btnStartSearch.Name = "btnStartSearch";
             this.btnStartSearch.Size = new System.Drawing.Size(121, 23);
             this.btnStartSearch.TabIndex = 11;
@@ -160,15 +162,15 @@ namespace aclogview.Tools
             // 
             this.txtOutputFolder.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtOutputFolder.Location = new System.Drawing.Point(122, 55);
+            this.txtOutputFolder.Location = new System.Drawing.Point(92, 55);
             this.txtOutputFolder.Name = "txtOutputFolder";
-            this.txtOutputFolder.Size = new System.Drawing.Size(616, 20);
+            this.txtOutputFolder.Size = new System.Drawing.Size(646, 20);
             this.txtOutputFolder.TabIndex = 18;
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(24, 58);
+            this.label4.Location = new System.Drawing.Point(15, 58);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(71, 13);
             this.label4.TabIndex = 19;
@@ -182,7 +184,7 @@ namespace aclogview.Tools
             // chkMultiThread
             // 
             this.chkMultiThread.AutoSize = true;
-            this.chkMultiThread.Location = new System.Drawing.Point(384, 85);
+            this.chkMultiThread.Location = new System.Drawing.Point(386, 85);
             this.chkMultiThread.Name = "chkMultiThread";
             this.chkMultiThread.Size = new System.Drawing.Size(134, 17);
             this.chkMultiThread.TabIndex = 21;
@@ -201,10 +203,10 @@ namespace aclogview.Tools
             this.columnEnabled,
             this.columnName,
             this.columnDescription});
-            this.dataGridView1.Location = new System.Drawing.Point(12, 110);
+            this.dataGridView1.Location = new System.Drawing.Point(12, 135);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.RowHeadersVisible = false;
-            this.dataGridView1.Size = new System.Drawing.Size(760, 426);
+            this.dataGridView1.Size = new System.Drawing.Size(760, 402);
             this.dataGridView1.TabIndex = 22;
             // 
             // columnEnabled
@@ -232,18 +234,38 @@ namespace aclogview.Tools
             this.chkExcludeNonRetailPcaps.AutoSize = true;
             this.chkExcludeNonRetailPcaps.Checked = true;
             this.chkExcludeNonRetailPcaps.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(219, 85);
+            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(227, 85);
             this.chkExcludeNonRetailPcaps.Name = "chkExcludeNonRetailPcaps";
             this.chkExcludeNonRetailPcaps.Size = new System.Drawing.Size(150, 17);
             this.chkExcludeNonRetailPcaps.TabIndex = 23;
             this.chkExcludeNonRetailPcaps.Text = "Exclude Non-Retail Pcaps";
             this.chkExcludeNonRetailPcaps.UseVisualStyleBackColor = true;
             // 
+            // tbCreatureName
+            // 
+            this.tbCreatureName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tbCreatureName.Location = new System.Drawing.Point(225, 111);
+            this.tbCreatureName.Name = "tbCreatureName";
+            this.tbCreatureName.Size = new System.Drawing.Size(247, 20);
+            this.tbCreatureName.TabIndex = 24;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(13, 115);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(197, 13);
+            this.label2.TabIndex = 25;
+            this.label2.Text = "Creature Name (only for CombatScraper)";
+            // 
             // PcapScraperForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(784, 561);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.tbCreatureName);
             this.Controls.Add(this.chkExcludeNonRetailPcaps);
             this.Controls.Add(this.dataGridView1);
             this.Controls.Add(this.chkMultiThread);
@@ -288,5 +310,7 @@ namespace aclogview.Tools
         private System.Windows.Forms.DataGridViewTextBoxColumn columnDescription;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel4;
         private System.Windows.Forms.CheckBox chkExcludeNonRetailPcaps;
+        private System.Windows.Forms.TextBox tbCreatureName;
+        private System.Windows.Forms.Label label2;
     }
 }

--- a/aclogview/Tools/PcapScraperForm.Designer.cs
+++ b/aclogview/Tools/PcapScraperForm.Designer.cs
@@ -49,8 +49,6 @@ namespace aclogview.Tools
             this.columnName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.chkExcludeNonRetailPcaps = new System.Windows.Forms.CheckBox();
-            this.tbCreatureName = new System.Windows.Forms.TextBox();
-            this.label2 = new System.Windows.Forms.Label();
             this.statusStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.SuspendLayout();
@@ -184,7 +182,7 @@ namespace aclogview.Tools
             // chkMultiThread
             // 
             this.chkMultiThread.AutoSize = true;
-            this.chkMultiThread.Location = new System.Drawing.Point(386, 85);
+            this.chkMultiThread.Location = new System.Drawing.Point(248, 105);
             this.chkMultiThread.Name = "chkMultiThread";
             this.chkMultiThread.Size = new System.Drawing.Size(134, 17);
             this.chkMultiThread.TabIndex = 21;
@@ -234,38 +232,18 @@ namespace aclogview.Tools
             this.chkExcludeNonRetailPcaps.AutoSize = true;
             this.chkExcludeNonRetailPcaps.Checked = true;
             this.chkExcludeNonRetailPcaps.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(227, 85);
+            this.chkExcludeNonRetailPcaps.Location = new System.Drawing.Point(92, 105);
             this.chkExcludeNonRetailPcaps.Name = "chkExcludeNonRetailPcaps";
             this.chkExcludeNonRetailPcaps.Size = new System.Drawing.Size(150, 17);
             this.chkExcludeNonRetailPcaps.TabIndex = 23;
             this.chkExcludeNonRetailPcaps.Text = "Exclude Non-Retail Pcaps";
             this.chkExcludeNonRetailPcaps.UseVisualStyleBackColor = true;
             // 
-            // tbCreatureName
-            // 
-            this.tbCreatureName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tbCreatureName.Location = new System.Drawing.Point(225, 111);
-            this.tbCreatureName.Name = "tbCreatureName";
-            this.tbCreatureName.Size = new System.Drawing.Size(247, 20);
-            this.tbCreatureName.TabIndex = 24;
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(13, 115);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(197, 13);
-            this.label2.TabIndex = 25;
-            this.label2.Text = "Creature Name (only for CombatScraper)";
-            // 
             // PcapScraperForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(784, 561);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.tbCreatureName);
             this.Controls.Add(this.chkExcludeNonRetailPcaps);
             this.Controls.Add(this.dataGridView1);
             this.Controls.Add(this.chkMultiThread);
@@ -310,7 +288,5 @@ namespace aclogview.Tools
         private System.Windows.Forms.DataGridViewTextBoxColumn columnDescription;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel4;
         private System.Windows.Forms.CheckBox chkExcludeNonRetailPcaps;
-        private System.Windows.Forms.TextBox tbCreatureName;
-        private System.Windows.Forms.Label label2;
     }
 }

--- a/aclogview/Tools/PcapScraperForm.cs
+++ b/aclogview/Tools/PcapScraperForm.cs
@@ -60,6 +60,7 @@ namespace aclogview.Tools
         {
             using (FolderBrowserDialog openFolder = new FolderBrowserDialog())
             {
+                openFolder.SelectedPath = txtSearchPathRoot.Text;
                 if (openFolder.ShowDialog() == DialogResult.OK)
                     txtSearchPathRoot.Text = openFolder.SelectedPath;
             }
@@ -69,6 +70,7 @@ namespace aclogview.Tools
         {
             using (FolderBrowserDialog openFolder = new FolderBrowserDialog())
             {
+                openFolder.SelectedPath = txtOutputFolder.Text;
                 if (openFolder.ShowDialog() == DialogResult.OK)
                     txtOutputFolder.Text = openFolder.SelectedPath;
             }

--- a/aclogview/Tools/PcapScraperForm.cs
+++ b/aclogview/Tools/PcapScraperForm.cs
@@ -272,5 +272,7 @@ namespace aclogview.Tools
 
             toolStripStatusLabel3.Text = "Message Exceptions: " + totalExceptions.ToString("N0");
         }
+
+
     }
 }

--- a/aclogview/Tools/PcapScraperForm.cs
+++ b/aclogview/Tools/PcapScraperForm.cs
@@ -86,8 +86,6 @@ namespace aclogview.Tools
         private bool writeOutputAborted;
         private bool searchCompleted;
 
-        public string formCreatureName = "";
-
         private void btnStartSearch_Click(object sender, EventArgs e)
         {
             try
@@ -109,7 +107,7 @@ namespace aclogview.Tools
                 searchAborted = false;
                 writeOutputAborted = false;
                 searchCompleted = false;
-                formCreatureName = tbCreatureName.Text;
+                
 
                 UpdateToolStrip("Processing Files");
 
@@ -212,12 +210,6 @@ namespace aclogview.Tools
                 if (searchAborted || Disposing || IsDisposed)
                     return;
 
-                if (scraper.ToString() == "CombatDamageGiven")
-                {
-                    if (formCreatureName == "")
-                        MessageBox.Show("Creature Name is blank", "Warning!", (MessageBoxButtons)MessageBoxIcon.Exclamation);
-                    break;
-                }
                 var results = scraper.ProcessFileRecords(fileName, records, ref searchAborted);
 
                 lock (resultsLockObject)

--- a/aclogview/Tools/PcapScraperForm.cs
+++ b/aclogview/Tools/PcapScraperForm.cs
@@ -86,6 +86,8 @@ namespace aclogview.Tools
         private bool writeOutputAborted;
         private bool searchCompleted;
 
+        public string formCreatureName = "";
+
         private void btnStartSearch_Click(object sender, EventArgs e)
         {
             try
@@ -107,6 +109,7 @@ namespace aclogview.Tools
                 searchAborted = false;
                 writeOutputAborted = false;
                 searchCompleted = false;
+                formCreatureName = tbCreatureName.Text;
 
                 UpdateToolStrip("Processing Files");
 
@@ -114,7 +117,6 @@ namespace aclogview.Tools
                 btnChangeSearchPathRoot.Enabled = false;
                 dataGridView1.Enabled = false;
                 btnStopSearch.Enabled = true;
-
                 timer1.Start();
 
                 ThreadPool.QueueUserWorkItem((state) =>
@@ -210,6 +212,12 @@ namespace aclogview.Tools
                 if (searchAborted || Disposing || IsDisposed)
                     return;
 
+                if (scraper.ToString() == "CombatDamageGiven")
+                {
+                    if (formCreatureName == "")
+                        MessageBox.Show("Creature Name is blank", "Warning!", (MessageBoxButtons)MessageBoxIcon.Exclamation);
+                    break;
+                }
                 var results = scraper.ProcessFileRecords(fileName, records, ref searchAborted);
 
                 lock (resultsLockObject)

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace aclogview.Tools.Scrapers
+{
+    class CombatDamageGiven :Scraper
+    {
+
+        public override string Description => "Exports Damage given to a creature by a player";
+
+        private uint damageDone = 0;
+        private uint damageType = 0;
+        private bool crititcalHit = false;
+        private string creatureName = "Rynthid Minion";
+
+        public override void Reset()
+        {
+            damageDone = 0;
+            damageType = 0;
+            crititcalHit = false;
+        }
+    
+
+        public override (int hits, int messageExceptions) ProcessFileRecords(string fileName, List<PacketRecord> records, ref bool searchAborted)
+        {
+            int hits = 0;
+            int messageExceptions = 0;
+            
+
+            foreach (PacketRecord record in records)
+            {
+                if (searchAborted)
+                    return (hits, messageExceptions);
+
+                try
+                {
+                    if (record.data.Length <= 4)
+                        continue;
+
+                    if (record.isSend)
+                        continue;
+
+                    using (var memoryStream = new MemoryStream(record.data))
+                    using (var binaryReader = new BinaryReader(memoryStream))
+                    {
+                        var messageCode = binaryReader.ReadUInt32();
+
+                        // if (messageCode == (uint)PacketOpcode.ATTACKER_NOTIFICATION_EVENT) // 0x01B1
+                        if (messageCode == (uint)PacketOpcode.WEENIE_ORDERED_EVENT) // 0x01B1
+                        {
+                            // var message = CM_Login.Login__CharacterSet.read(binaryReader);
+                            // var message = CM_Combat.AttackerNotificationEvent.read(binaryReader);
+                            var message = CM_Combat.AttackerNotificationEvent.read(binaryReader);
+
+                            lock (this)
+                            {
+                                if (message.defenders_name.ToString() == creatureName)
+                                {
+                                    hits++;
+                                    damageDone = message.damage;
+                                    damageType = message.damage_type;
+                                    if (message.critical == 1)
+                                        crititcalHit = true;
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (InvalidDataException)
+                {
+                    // This is a pcap parse error
+                }
+                catch (Exception ex)
+                {
+                    messageExceptions++;
+                    // Do something with the exception maybe
+                }
+            }
+
+            return (hits, messageExceptions);
+        }
+
+        public override void WriteOutput(string destinationRoot, ref bool writeOutputAborted)
+        {
+            var sb = new StringBuilder();
+            string header = $"Combat Damage for {creatureName} \r\n" +
+                            $"Damage,DamageType,Critical\r\n";
+            string combatInfo = $"{damageDone},{damageType},{crititcalHit}";
+
+            var fileName = GetFileName(destinationRoot, ".csv");
+            File.WriteAllText(fileName, header + combatInfo);
+        }
+
+    }
+}

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -57,7 +57,7 @@ namespace aclogview.Tools.Scrapers
             //haveCreatureName = false;
         }
     
-        public (int hits, int messageExceptions, string combatInfo) ProcessFileRecords(string fileName, List<PacketRecord> records, List<string> creatureNames, ref bool useCharList, ref bool searchAborted)
+        public (int hits, int messageExceptions, string combatInfo, HashSet<uint> wieldedItemIDs) ProcessFileRecords(string fileName, List<PacketRecord> records, List<string> creatureNames, ref bool useCharList, ref bool searchAborted)
         {
             int hits = 0;
             int messageExceptions = 0;
@@ -71,7 +71,7 @@ namespace aclogview.Tools.Scrapers
             foreach (PacketRecord record in records)
             {
                 if (searchAborted)
-                    return (hits, messageExceptions, combatInfoResults.ToString());
+                    return (hits, messageExceptions, combatInfoResults.ToString(), wieldedItemIDs);
 
                 try
                 {
@@ -126,6 +126,7 @@ namespace aclogview.Tools.Scrapers
                                 {
                                     wieldedItemID = parsedWieldInfo.i_item;
                                     wieldedItemIDs.Add(parsedWieldInfo.i_item);
+
                                 }
                                 
                             }
@@ -233,19 +234,19 @@ namespace aclogview.Tools.Scrapers
                 }
             }
             
-            return (hits, messageExceptions, combatInfoResults.ToString());
+            return (hits, messageExceptions, combatInfoResults.ToString(), wieldedItemIDs);
         }
 
         public void WriteOutput(string destinationRoot, string scrapeResults, string fileNameHeading, ref bool writeOutputAborted)
         {
             var sb = new StringBuilder();
-            string header = $"Combat Damage Given to a creature from a player \r\n" +
-                            $"CharName,Attack,WeaponName,DamageType,Damage,Creature,Critical\r\n";
+            //string header = $"Combat Damage Given to a creature from a player \r\n" +
+            //                $"CharName,Attack,WeaponName,DamageType,Damage,Creature,Critical\r\n";
             //string combatInfoResults.Append( = $"{damageDone},{damageType},{crititcalHit}";
 
             var fileName = GetFileNameCombat(destinationRoot, fileNameHeading, ".csv");
             //if (creatureName != "")
-                File.WriteAllText(fileName, header + scrapeResults);
+                File.WriteAllText(fileName, scrapeResults);
 
             // haveCreatureName = false;
         }

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -13,6 +13,19 @@ namespace aclogview.Tools.Scrapers
 
         public string Description => "Exports Damage given to a creature by a player from a melee or missile weapon";
 
+
+        // Lists for Magic Verbs (for getting Magic Damage Type)
+        List<string> SlashVerbs = new List<string>(new string[] { "mangle", "mangles", "slash", "slashes", "cuts", "scratch", "scratches" });
+        List<string> PierceVerbs = new List<string>(new string[] { "gore", "gores", "impale", "impales", "stab", "stabs", "nick", "nicks" });
+        List<string> BludgeVerbs = new List<string>(new string[] { "crush", "crushes", "smash", "smashes", "bash", "bashes", "graze", "grazes" });
+        List<string> FireVerbs = new List<string>(new string[] { "incinerate", "incinerates", "burn", "burns", "scorch", "scorches", "singe", "singes" });
+        List<string> ColdVerbs = new List<string>(new string[] { "freeze", "freezes", "frost", "frosts", "chill", "chills", "numb", "numbs" });        
+        List<string> AcidVerbs = new List<string>(new string[] { "dissolve", "dissolves", "corrode", "corrodes", "sear", "sears", "blister", "blisters" });
+        List<string> ElectricVerbs = new List<string>(new string[] { "blast", "blasts", "jolt", "jolts", "shock", "shocks", "spark", "sparks" });        
+        List<string> NetherVerbs = new List<string>(new string[] { "eradicate", "eradicates", "wither", "withers", "twist", "twists", "scar", "scars" });
+        List<string> HealthVerbs = new List<string>(new string[] { "deplete", "depletes", "siphon", "siphons", "exhaust", "exhausts", "drain", "drains" });
+
+
         private uint damageDone = 0;
         private string damageType = "";
         private bool crititcalHit = false;
@@ -166,6 +179,70 @@ namespace aclogview.Tools.Scrapers
             if (creature == "")
                 creature = "BlankCreature";
             return Path.Combine(destinationRoot, creature + "-" + DateTime.UtcNow.ToString("yyyy-MM-dd HH-mm-ss") + " " + GetType().Name + extension);
+        }
+        protected (string magicDamageType, string creatureName, int damageAmount) DecodeMagicDamageMessage(string magicMessage)
+        {
+            string magicDamageType = "";
+            string creatureName = "";
+            int damageAmount = 0;
+
+
+
+
+
+
+
+            return (magicDamageType, creatureName, damageAmount);
+        }
+        protected string GetMagicDamageType(string magicVerb)
+        {
+            string magicDamageType = "Unknown";
+
+            if (SlashVerbs.Contains(magicVerb) == true)
+            {
+                magicDamageType = "Slash";
+                return magicDamageType;
+            }
+            if (PierceVerbs.Contains(magicVerb) == true)
+            {
+                magicDamageType = "Pierce";
+                return magicDamageType;
+            }
+            if (BludgeVerbs.Contains(magicVerb) == true)
+            {
+                magicDamageType = "Bludge";
+                return magicDamageType;
+            }
+            if (FireVerbs.Contains(magicVerb) == true)
+            {
+                magicDamageType = "Fire";
+                return magicDamageType;
+            }
+            if (ColdVerbs.Contains(magicVerb) == true)
+            {
+                magicDamageType = "Cold";
+                return magicDamageType;
+            }
+            if (AcidVerbs.Contains(magicVerb) == true)
+            {
+                magicDamageType = "Acid";
+                return magicDamageType;
+            }
+            if (ElectricVerbs.Contains(magicVerb) == true)
+            {
+                magicDamageType = "Electric";
+                return magicDamageType;
+            }
+            if (NetherVerbs.Contains(magicVerb) == true)
+            {
+                magicDamageType = "Nether";
+                return magicDamageType;
+            }
+            if (HealthVerbs.Contains(magicVerb) == true)
+                magicDamageType = "HealthDrain";
+
+            return magicDamageType;
+
         }
     }
 }

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -16,7 +16,11 @@ namespace aclogview.Tools.Scrapers
         // List for Character Names
         private readonly Dictionary<string, Dictionary<uint, string>> accounts = new Dictionary<string, Dictionary<uint, string>>();
         private Dictionary<uint, string> charNames = new Dictionary<uint, string>();
-        private Dictionary<uint, string> wieldedItemNames = new Dictionary<uint, string>();
+        // private Dictionary<uint, string> wieldedItems = new Dictionary<uint, string>();
+
+        //List<uint> wieldedItemIDs = new List<uint>;
+        HashSet<uint> wieldedItemIDs = new HashSet<uint>();
+        
 
         // Lists for Magic Verbs (for getting Magic Damage Type)
         List<string> SlashVerbs = new List<string>() { "mangle", "mangles", "slash", "slashes", "cut", "cuts", "scratch", "scratches" };
@@ -36,7 +40,7 @@ namespace aclogview.Tools.Scrapers
         private uint damageDone = 0;
         private string damageType = "";
         private bool crititcalHit = false;
-        private string combatInfo = "";
+        private string combatInfo;
 
         // private bool useCharList = false;
 
@@ -57,8 +61,8 @@ namespace aclogview.Tools.Scrapers
         {
             int hits = 0;
             int messageExceptions = 0;
-            string combatInfoResults = "";
-            
+            //string combatInfoResults.Append(Results = "";
+            StringBuilder combatInfoResults= new StringBuilder();
 
             // Loads Character List from file if checked
             if (useCharList)
@@ -67,7 +71,7 @@ namespace aclogview.Tools.Scrapers
             foreach (PacketRecord record in records)
             {
                 if (searchAborted)
-                    return (hits, messageExceptions, combatInfoResults);
+                    return (hits, messageExceptions, combatInfoResults.ToString());
 
                 try
                 {
@@ -121,6 +125,7 @@ namespace aclogview.Tools.Scrapers
                                 if ((parsedWieldInfo.i_equipMask == 1048576) || (parsedWieldInfo.i_equipMask == 4194304) || (parsedWieldInfo.i_equipMask == 16777216))
                                 {
                                     wieldedItemID = parsedWieldInfo.i_item;
+                                    wieldedItemIDs.Add(parsedWieldInfo.i_item);
                                 }
                                 
                             }
@@ -148,7 +153,7 @@ namespace aclogview.Tools.Scrapers
                                     if (parsedCombatAttack.critical == 1)
                                         crititcalHit = true;
 
-                                    combatInfo += $"{GetCharacterName(character)},{"Melee/Missile"},{GetWieldedItemName(wieldedItemID)},{damageType},{damageDone},{parsedCombatAttack.defenders_name},{crititcalHit}\r\n";
+                                    combatInfoResults.Append($"{GetCharacterName(character)},{"Melee/Missile"},{GetWieldedItemName(wieldedItemID)},{damageType},{damageDone},{parsedCombatAttack.defenders_name},{crititcalHit}\r\n");
                                     Reset();
                                 }
                             }
@@ -193,7 +198,7 @@ namespace aclogview.Tools.Scrapers
                                         string magicCharName = "Not Found";
                                         if (defenderCharID != 0)
                                             magicCharName = GetCharacterName(defenderCharID);
-                                        combatInfo += $"{magicCharName},{"Magic"},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
+                                        combatInfoResults.Append($"{magicCharName},{"Magic"},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n");
                                     }
                                 }
                             }
@@ -210,7 +215,7 @@ namespace aclogview.Tools.Scrapers
                                         string magicCharName = "Not Found";
                                         if (defenderCharID != 0)
                                             magicCharName = GetCharacterName(defenderCharID);
-                                        combatInfo += $"{magicCharName},{"Magic"},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
+                                        combatInfoResults.Append($"{magicCharName},{"Magic"},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n");
                                     }
                                 }
                             }
@@ -228,7 +233,7 @@ namespace aclogview.Tools.Scrapers
                 }
             }
             
-            return (hits, messageExceptions, combatInfo);
+            return (hits, messageExceptions, combatInfoResults.ToString());
         }
 
         public void WriteOutput(string destinationRoot, string scrapeResults, string fileNameHeading, ref bool writeOutputAborted)
@@ -236,7 +241,7 @@ namespace aclogview.Tools.Scrapers
             var sb = new StringBuilder();
             string header = $"Combat Damage Given to a creature from a player \r\n" +
                             $"CharName,Attack,WeaponName,DamageType,Damage,Creature,Critical\r\n";
-            //string combatInfo = $"{damageDone},{damageType},{crititcalHit}";
+            //string combatInfoResults.Append( = $"{damageDone},{damageType},{crititcalHit}";
 
             var fileName = GetFileNameCombat(destinationRoot, fileNameHeading, ".csv");
             //if (creatureName != "")

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -74,8 +74,8 @@ namespace aclogview.Tools.Scrapers
                     if (record.data.Length <= 4)
                         continue;
 
-                    if (record.isSend)
-                        continue;
+                    //if (record.isSend)
+                    //    continue;
 
                     using (var memoryStream = new MemoryStream(record.data))
                     using (var binaryReader = new BinaryReader(memoryStream))
@@ -114,10 +114,15 @@ namespace aclogview.Tools.Scrapers
                         {
                             var sequence = binaryReader.ReadUInt32(); // Sequence
                             var _event = binaryReader.ReadUInt32(); // Event
-                            if (_event == (uint)PacketOpcode.INVENTORY_WIELD_OBJ_EVENT) // Seeing if event matches 
+                            if (_event == (uint)PacketOpcode.Evt_Inventory__GetAndWieldItem_ID) // Seeing if event matches 
                             {
                                 var parsedWieldInfo = CM_Inventory.GetAndWieldItem.read(binaryReader);
-                                wieldedItemID = parsedWieldInfo.i_item;
+
+                                if ((parsedWieldInfo.i_equipMask == 1048576) || (parsedWieldInfo.i_equipMask == 4194304) || (parsedWieldInfo.i_equipMask == 16777216))
+                                {
+                                    wieldedItemID = parsedWieldInfo.i_item;
+                                }
+                                
                             }
                         }
                         // Getting Melee/Missile Damage
@@ -188,7 +193,7 @@ namespace aclogview.Tools.Scrapers
                                         string magicCharName = "Not Found";
                                         if (defenderCharID != 0)
                                             magicCharName = GetCharacterName(defenderCharID);
-                                        combatInfo += $"{magicCharName},{"Magic"},{decodedMagicChat.magicDamageType},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
+                                        combatInfo += $"{magicCharName},{"Magic"},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
                                     }
                                 }
                             }
@@ -205,7 +210,7 @@ namespace aclogview.Tools.Scrapers
                                         string magicCharName = "Not Found";
                                         if (defenderCharID != 0)
                                             magicCharName = GetCharacterName(defenderCharID);
-                                        combatInfo += $"{magicCharName},{"Magic"},{decodedMagicChat.magicDamageType},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
+                                        combatInfo += $"{magicCharName},{"Magic"},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
                                     }
                                 }
                             }
@@ -408,6 +413,9 @@ namespace aclogview.Tools.Scrapers
             {
                 wieldedItemName = nameValue;
             }
+
+            // For now just sending ID as text
+            wieldedItemName = wieldedItemID.ToString();
 
             return wieldedItemName;
         }

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -19,8 +19,10 @@ namespace aclogview.Tools.Scrapers
         // private Dictionary<uint, string> wieldedItems = new Dictionary<uint, string>();
 
         //List<uint> wieldedItemIDs = new List<uint>;
+
+        // For exporting weenies
         HashSet<uint> wieldedItemIDs = new HashSet<uint>();
-        
+        HashSet<uint> characterIDs = new HashSet<uint>();
 
         // Lists for Magic Verbs (for getting Magic Damage Type)
         List<string> SlashVerbs = new List<string>() { "mangle", "mangles", "slash", "slashes", "cut", "cuts", "scratch", "scratches" };
@@ -108,6 +110,7 @@ namespace aclogview.Tools.Scrapers
                                         {
                                             account[character.gid_] = character.name_.m_buffer;
                                             charNames.Add(ConvertToUinteger(character.gid_.ToString()), character.name_.m_buffer);
+                                            characterIDs.Add(character.gid_);
                                         }
                                     }
                                 }
@@ -155,6 +158,7 @@ namespace aclogview.Tools.Scrapers
                                         crititcalHit = true;
 
                                     combatInfoResults.Append($"{GetCharacterName(character)},{"Melee/Missile"},{GetWieldedItemName(wieldedItemID)},{damageType},{damageDone},{parsedCombatAttack.defenders_name},{crititcalHit}\r\n");
+                                    characterIDs.Add(character);
                                     Reset();
                                 }
                             }
@@ -199,6 +203,7 @@ namespace aclogview.Tools.Scrapers
                                         string magicCharName = "Not Found";
                                         if (defenderCharID != 0)
                                             magicCharName = GetCharacterName(defenderCharID);
+                                        characterIDs.Add(defenderCharID);
                                         combatInfoResults.Append($"{magicCharName},{"Magic"},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n");
                                     }
                                 }
@@ -216,6 +221,7 @@ namespace aclogview.Tools.Scrapers
                                         string magicCharName = "Not Found";
                                         if (defenderCharID != 0)
                                             magicCharName = GetCharacterName(defenderCharID);
+                                        characterIDs.Add(defenderCharID);
                                         combatInfoResults.Append($"{magicCharName},{"Magic"},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n");
                                     }
                                 }

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -13,6 +13,11 @@ namespace aclogview.Tools.Scrapers
     {
         public string Description => "Exports Damage given to a creature by a player from a melee or missile weapon";
 
+        // List for Character Names
+        private readonly Dictionary<string, Dictionary<uint, string>> accounts = new Dictionary<string, Dictionary<uint, string>>();
+        private Dictionary<uint, string> charNames = new Dictionary<uint, string>();
+        private Dictionary<uint, string> wieldedItemNames = new Dictionary<uint, string>();
+
         // Lists for Magic Verbs (for getting Magic Damage Type)
         List<string> SlashVerbs = new List<string>() { "mangle", "mangles", "slash", "slashes", "cut", "cuts", "scratch", "scratches" };
         List<string> PierceVerbs = new List<string>() { "gore", "gores", "impale", "impales", "stab", "stabs", "nick", "nicks" };
@@ -32,9 +37,13 @@ namespace aclogview.Tools.Scrapers
         private string damageType = "";
         private bool crititcalHit = false;
         private string combatInfo = "";
+
+        // private bool useCharList = false;
+
         //private bool haveCreatureName = false;
         //private string creatureName = "";
-
+        private uint defenderCharID = 0;
+        private uint wieldedItemID = 0;
 
         public void Reset()
         {
@@ -44,11 +53,16 @@ namespace aclogview.Tools.Scrapers
             //haveCreatureName = false;
         }
     
-        public (int hits, int messageExceptions, string combatInfo) ProcessFileRecords(string fileName, List<PacketRecord> records, List<string> creatureNames, ref bool searchAborted)
+        public (int hits, int messageExceptions, string combatInfo) ProcessFileRecords(string fileName, List<PacketRecord> records, List<string> creatureNames, ref bool useCharList, ref bool searchAborted)
         {
             int hits = 0;
             int messageExceptions = 0;
             string combatInfoResults = "";
+            
+
+            // Loads Character List from file if checked
+            if (useCharList)
+                GetCharList();
 
             foreach (PacketRecord record in records)
             {
@@ -67,35 +81,94 @@ namespace aclogview.Tools.Scrapers
                     using (var binaryReader = new BinaryReader(memoryStream))
                     {
                         var messageCode = binaryReader.ReadUInt32();
-                        // Getting Melee/Missile Damage
-                        if (messageCode == (uint)PacketOpcode.WEENIE_ORDERED_EVENT) // 0x7BD
+                        // Getting Account and Character Info
+                        if (useCharList == false)
                         {
-
-                            var character = binaryReader.ReadUInt32(); // Character
-                            var sequence = binaryReader.ReadUInt32(); // Sequence
-                            var _event = binaryReader.ReadUInt32(); // Event
-
-                            if (_event == (uint)PacketOpcode.ATTACKER_NOTIFICATION_EVENT) // Seeing if event matches 
+                            if (messageCode == (uint)PacketOpcode.Evt_Login__CharacterSet_ID) // 0xF658
                             {
+                                var message = CM_Login.Login__CharacterSet.read(binaryReader);
 
-                                var parsedCombatAttack = CM_Combat.AttackerNotificationEvent.read(binaryReader);
-
-                                lock (this)
+                                lock (accounts)
                                 {
-                                    if (creatureNames.Contains(parsedCombatAttack.defenders_name.ToString()) == true)  // Seeing if creature Name matches list of creatures searching for.
+                                    if (!accounts.TryGetValue(message.account_.m_buffer, out var account))
                                     {
                                         hits++;
-                                        damageDone = parsedCombatAttack.damage;
-                                        damageType = DamageType(parsedCombatAttack.damage_type);
-                                        if (parsedCombatAttack.critical == 1)
-                                            crititcalHit = true;
-                                        combatInfo += $"{"Melee/Missile"},{damageType},{damageDone},{parsedCombatAttack.defenders_name},{crititcalHit}\r\n";
-                                        Reset();
+
+                                        account = new Dictionary<uint, string>();
+                                        accounts[message.account_.m_buffer] = account;
+                                    }
+
+                                    foreach (var character in message.set_)
+                                    {
+                                        if (!account.ContainsKey(character.gid_))
+                                        {
+                                            account[character.gid_] = character.name_.m_buffer;
+                                            charNames.Add(ConvertToUinteger(character.gid_.ToString()), character.name_.m_buffer);
+                                        }
                                     }
                                 }
                             }
+                        }
+                        // Getting Wield Item - Only be shown if item has been switched.
+                        if (messageCode == 63409) //(uint)PacketOpcode.ORDERED_EVENT) // 0xF7B1)
+                        {
+                            var sequence = binaryReader.ReadUInt32(); // Sequence
+                            var _event = binaryReader.ReadUInt32(); // Event
+                            if (_event == (uint)PacketOpcode.INVENTORY_WIELD_OBJ_EVENT) // Seeing if event matches 
+                            {
+                                var parsedWieldInfo = CM_Inventory.GetAndWieldItem.read(binaryReader);
+                                wieldedItemID = parsedWieldInfo.i_item;
+                            }
+                        }
+                        // Getting Melee/Missile Damage
+                        if (messageCode == (uint)PacketOpcode.WEENIE_ORDERED_EVENT) // 0xF7B0)
+                        {
+
+                        var character = binaryReader.ReadUInt32(); // Character
+                        var sequence = binaryReader.ReadUInt32(); // Sequence
+                        var _event = binaryReader.ReadUInt32(); // Event
+
+                        if (_event == (uint)PacketOpcode.ATTACKER_NOTIFICATION_EVENT) // Seeing if event matches 
+                        {
+
+                            var parsedCombatAttack = CM_Combat.AttackerNotificationEvent.read(binaryReader);
+
+                            lock (this)
+                            {
+                                if (creatureNames.Contains(parsedCombatAttack.defenders_name.ToString()) == true)  // Seeing if creature Name matches list of creatures searching for.
+                                {
+                                    hits++;
+                                    damageDone = parsedCombatAttack.damage;
+                                    damageType = DamageType(parsedCombatAttack.damage_type);
+                                    if (parsedCombatAttack.critical == 1)
+                                        crititcalHit = true;
+
+                                    combatInfo += $"{GetCharacterName(character)},{"Melee/Missile"},{GetWieldedItemName(wieldedItemID)},{damageType},{damageDone},{parsedCombatAttack.defenders_name},{crititcalHit}\r\n";
+                                    Reset();
+                                }
+                            }
+                        }
+                        // for getting charID for Magic chars
+                        if (_event == (uint)PacketOpcode.DEFENDER_NOTIFICATION_EVENT) // Seeing if event matches
+                        {
+                            defenderCharID = character;
 
                         }
+
+                        }
+                        // Getting Character ID from 0x01BF: Combat_QueryHealth 
+                        //if (messageCode == (uint)PacketOpcode.Evt_Combat__QueryHealth_ID) // 0xF7E0
+                        //{
+                        //    var character = binaryReader.ReadUInt32(); // Character
+                        //    var sequence = binaryReader.ReadUInt32(); // Sequence
+                        //    var _event = binaryReader.ReadUInt32(); // Event
+
+                        //    var parsedHealth = CM_Combat.QueryHealth.read(binaryReader);
+
+
+                        //}
+
+
                         // Getting Magic Attack Damage
                         if (messageCode == (uint)PacketOpcode.Evt_Communication__TextboxString_ID) // 0xF7E0
                         {
@@ -112,7 +185,10 @@ namespace aclogview.Tools.Scrapers
                                     if (creatureNames.Contains(decodedMagicChat.creatureName) == true)  // Seeing if creature Name matches list of creatures searching for.
                                     {
                                         hits++;
-                                        combatInfo += $"{"Magic"},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
+                                        string magicCharName = "Not Found";
+                                        if (defenderCharID != 0)
+                                            magicCharName = GetCharacterName(defenderCharID);
+                                        combatInfo += $"{magicCharName},{"Magic"},{decodedMagicChat.magicDamageType},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
                                     }
                                 }
                             }
@@ -126,7 +202,10 @@ namespace aclogview.Tools.Scrapers
                                     if (creatureNames.Contains(decodedMagicChat.creatureName) == true)  // Seeing if creature Name matches list of creatures searching for.
                                     {
                                         hits++;
-                                        combatInfo += $"{"Magic"},{decodedMagicChat.magicDamageType},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
+                                        string magicCharName = "Not Found";
+                                        if (defenderCharID != 0)
+                                            magicCharName = GetCharacterName(defenderCharID);
+                                        combatInfo += $"{magicCharName},{"Magic"},{decodedMagicChat.magicDamageType},{GetWieldedItemName(wieldedItemID)},{decodedMagicChat.damageAmount},{decodedMagicChat.creatureName},{decodedMagicChat.crit}\r\n";
                                     }
                                 }
                             }
@@ -151,7 +230,7 @@ namespace aclogview.Tools.Scrapers
         {
             var sb = new StringBuilder();
             string header = $"Combat Damage Given to a creature from a player \r\n" +
-                            $"Attack,DamageType,Damage,Creature,Critical\r\n";
+                            $"CharName,Attack,WeaponName,DamageType,Damage,Creature,Critical\r\n";
             //string combatInfo = $"{damageDone},{damageType},{crititcalHit}";
 
             var fileName = GetFileNameCombat(destinationRoot, fileNameHeading, ".csv");
@@ -297,10 +376,53 @@ namespace aclogview.Tools.Scrapers
             return magicDamageType;
 
         }
+
+        private void GetCharList()
+        {
+            uint charID = 0;
+            string charValue = "";
+
+            foreach (string line in File.ReadLines(@"Lists\CharacterList.txt"))
+            {
+                string[] listValues = line.Split(',');
+
+                charNames.Add(ConvertToUinteger(listValues[0]), listValues[1]);
+            }
+
+        }
+        private string GetCharacterName (uint charID)
+        {
+            string charName = "Not Found";            
+            if (charNames.TryGetValue(charID, out string nameValue))
+            {
+                charName = nameValue;
+            }
+
+            return charName;
+        }
+
+        private string GetWieldedItemName(uint wieldedItemID)
+        {
+            string wieldedItemName = "Not Found";
+            if (charNames.TryGetValue(wieldedItemID, out string nameValue))
+            {
+                wieldedItemName = nameValue;
+            }
+
+            return wieldedItemName;
+        }
+
         public static int ConvertToInteger(string text)
         {
             int i = 0;
-            Int32.TryParse(text, out i);
+            Int32.TryParse(text, out i);            
+            return i;
+        }
+        public static uint ConvertToUinteger(string text)
+        {
+            uint i = 0;
+            //Int32.TryParse(text, out i);
+            UInt32.TryParse(text, out i);
             return i;
         }
     }

--- a/aclogview/Tools/Scrapers/CombatDamageGiven.cs
+++ b/aclogview/Tools/Scrapers/CombatDamageGiven.cs
@@ -18,12 +18,13 @@ namespace aclogview.Tools.Scrapers
         private bool crititcalHit = false;
         private string creatureName = "";
         private string combatInfo = "";
-
+        private bool haveCreatureName = false;
         public override void Reset()
         {
             damageDone = 0;
             damageType = "";
             crititcalHit = false;
+            //haveCreatureName = false;
         }
     
         public override (int hits, int messageExceptions) ProcessFileRecords(string fileName, List<PacketRecord> records, ref bool searchAborted)
@@ -31,18 +32,23 @@ namespace aclogview.Tools.Scrapers
             int hits = 0;
             int messageExceptions = 0;
 
-            using (CreatureName form = new CreatureName())
+            if (haveCreatureName == false)
             {
-                DialogResult dr = form.ShowDialog();
-                if (dr == DialogResult.OK)
+                using (CreatureName form = new CreatureName())
                 {
-                    creatureName = form.creatureName;
-                    if (creatureName == "")
-                        return (hits, messageExceptions);
-                }
-                else
-                {
-                    return (hits, messageExceptions);
+                    DialogResult dr = form.ShowDialog();
+                    if (dr == DialogResult.OK)
+                    {
+                        creatureName = form.creatureName;
+                        haveCreatureName = true;
+                        if (creatureName == "")
+                            return (hits, messageExceptions);
+                    }
+                    else
+                    {
+                        searchAborted = true;
+                        //return (hits, messageExceptions);
+                    }
                 }
             }
 
@@ -118,6 +124,8 @@ namespace aclogview.Tools.Scrapers
             var fileName = GetFileNameCombat(destinationRoot, creatureName, ".csv");
             if (creatureName != "")
                 File.WriteAllText(fileName, header + combatInfo);
+
+            haveCreatureName = false;
         }
 
         private string DamageType (uint dtype)

--- a/aclogview/Tools/Scrapers/PlayerExporter.cs
+++ b/aclogview/Tools/Scrapers/PlayerExporter.cs
@@ -11,9 +11,9 @@ using aclogview.ACE_Helpers;
 
 namespace aclogview.Tools.Scrapers
 {
-    class PlayerWeaponExport : Scraper
+    class PlayerExporter : Scraper
     {
-        public override string Description => "Exports players and their weapons";
+        public override string Description => "Exports players and their inventory";
 
         // TODO: player.Character.CharacterPropertiesQuestRegistry
         // TODO: player.Character.HairTexture
@@ -492,7 +492,6 @@ namespace aclogview.Tools.Scrapers
             var biotaWriter = new ACE.Database.SQLFormatters.Shard.BiotaSQLWriter();
             var characterWriter = new ACE.Database.SQLFormatters.Shard.CharacterSQLWriter();
 
-            
             var rwLock = new ReaderWriterLockSlim();
 
             // Export players by login event
@@ -639,13 +638,10 @@ namespace aclogview.Tools.Scrapers
                         if (!woiBeingUsed.AppraiseInfoReceived)
                             partialExportsNoAppraisalInfo.Add($"{woiBeingUsed.Biota.Id:X8}:{woiBeingUsed.Name}");
 
-                        SetBiotaPopulatedCollectionsItem(woiBeingUsed.Biota);
+                        SetBiotaPopulatedCollections(woiBeingUsed.Biota);
 
-                        if ((woiBeingUsed.Biota.WeenieType == 3)||(woiBeingUsed.Biota.WeenieType == 6)||(woiBeingUsed.Biota.WeenieType == 35))
-                        {
-                            using (StreamWriter outputFile = new StreamWriter(fileName, false))
-                                biotaWriter.CreateSQLINSERTStatement(woiBeingUsed.Biota, outputFile);
-                        }
+                        using (StreamWriter outputFile = new StreamWriter(fileName, false))
+                            biotaWriter.CreateSQLINSERTStatement(woiBeingUsed.Biota, outputFile);
                     }
 
                     if (failedExportsUnknownWeenie.Count > 0)
@@ -688,8 +684,8 @@ namespace aclogview.Tools.Scrapers
                     }
 
 
-                    // var resutlsFileName = Path.Combine(loginEventDirectory, "results.txt");
-                    // File.WriteAllText(resutlsFileName, sb.ToString());
+                    var resutlsFileName = Path.Combine(loginEventDirectory, "results.txt");
+                    File.WriteAllText(resutlsFileName, sb.ToString());
                 }
             }
 
@@ -741,7 +737,7 @@ namespace aclogview.Tools.Scrapers
 
                         biota.WeenieType = (int)ACEBiotaCreator.DetermineWeenieType(biota, rwLock);
 
-                        SetBiotaPopulatedCollectionsCharacter(biota);
+                        SetBiotaPopulatedCollections(biota);
 
                         using (StreamWriter outputFile = new StreamWriter(fileName, false))
                             biotaWriter.CreateSQLINSERTStatement(biota, outputFile);
@@ -786,92 +782,30 @@ namespace aclogview.Tools.Scrapers
         {
             PopulatedCollectionFlags populatedCollectionFlags = 0;
 
-            //if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
+            if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
             if (biota.BiotaPropertiesAttribute != null && biota.BiotaPropertiesAttribute.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute;
             if (biota.BiotaPropertiesAttribute2nd != null && biota.BiotaPropertiesAttribute2nd.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute2nd;
-            //if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
-            //if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
-            //if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
+            if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
+            if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
+            if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
             if (biota.BiotaPropertiesBool != null && biota.BiotaPropertiesBool.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBool;
             if (biota.BiotaPropertiesCreateList != null && biota.BiotaPropertiesCreateList.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesCreateList;
             if (biota.BiotaPropertiesDID != null && biota.BiotaPropertiesDID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesDID;
-            //if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
+            if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
             if (biota.BiotaPropertiesEnchantmentRegistry != null && biota.BiotaPropertiesEnchantmentRegistry.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry;
-            //if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
+            if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
             if (biota.BiotaPropertiesFloat != null && biota.BiotaPropertiesFloat.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesFloat;
-            //if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
+            if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
             if (biota.BiotaPropertiesIID != null && biota.BiotaPropertiesIID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesIID;
             if (biota.BiotaPropertiesInt != null && biota.BiotaPropertiesInt.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt;
             if (biota.BiotaPropertiesInt64 != null && biota.BiotaPropertiesInt64.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt64;
             if (biota.BiotaPropertiesPalette != null && biota.BiotaPropertiesPalette.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPalette;
-            //if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
-            if (biota.BiotaPropertiesSkill != null && biota.BiotaPropertiesSkill.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSkill;
-            //if (biota.BiotaPropertiesSpellBook != null && biota.BiotaPropertiesSpellBook.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSpellBook;
-            if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
-            //if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
-            //if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
-
-            biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
-        }
-        private static void SetBiotaPopulatedCollectionsCharacter(Biota biota)
-        {
-            PopulatedCollectionFlags populatedCollectionFlags = 0;
-
-            //if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
-            if (biota.BiotaPropertiesAttribute != null && biota.BiotaPropertiesAttribute.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute;
-            if (biota.BiotaPropertiesAttribute2nd != null && biota.BiotaPropertiesAttribute2nd.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute2nd;
-            //if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
-            //if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
-            //if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
-            if (biota.BiotaPropertiesBool != null && biota.BiotaPropertiesBool.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBool;
-            //if (biota.BiotaPropertiesCreateList != null && biota.BiotaPropertiesCreateList.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesCreateList;
-            if (biota.BiotaPropertiesDID != null && biota.BiotaPropertiesDID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesDID;
-            //if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
-            if (biota.BiotaPropertiesEnchantmentRegistry != null && biota.BiotaPropertiesEnchantmentRegistry.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry;
-            //if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
-            if (biota.BiotaPropertiesFloat != null && biota.BiotaPropertiesFloat.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesFloat;
-            //if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
-            if (biota.BiotaPropertiesIID != null && biota.BiotaPropertiesIID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesIID;
-            if (biota.BiotaPropertiesInt != null && biota.BiotaPropertiesInt.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt;
-            if (biota.BiotaPropertiesInt64 != null && biota.BiotaPropertiesInt64.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt64;
-            if (biota.BiotaPropertiesPalette != null && biota.BiotaPropertiesPalette.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPalette;
-            //if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
+            if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
             if (biota.BiotaPropertiesSkill != null && biota.BiotaPropertiesSkill.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSkill;
             if (biota.BiotaPropertiesSpellBook != null && biota.BiotaPropertiesSpellBook.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSpellBook;
             if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
-            //if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
-            //if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
-
-            biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
-        }
-        private static void SetBiotaPopulatedCollectionsItem(Biota biota)
-        {
-            PopulatedCollectionFlags populatedCollectionFlags = 0;
-
-            //if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
-            if (biota.BiotaPropertiesAttribute != null && biota.BiotaPropertiesAttribute.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute;
-            if (biota.BiotaPropertiesAttribute2nd != null && biota.BiotaPropertiesAttribute2nd.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute2nd;
-            //if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
-            //if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
-            //if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
-            if (biota.BiotaPropertiesBool != null && biota.BiotaPropertiesBool.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBool;
-            //if (biota.BiotaPropertiesCreateList != null && biota.BiotaPropertiesCreateList.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesCreateList;
-            if (biota.BiotaPropertiesDID != null && biota.BiotaPropertiesDID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesDID;
-            //if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
-            if (biota.BiotaPropertiesEnchantmentRegistry != null && biota.BiotaPropertiesEnchantmentRegistry.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry;
-            //if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
-            if (biota.BiotaPropertiesFloat != null && biota.BiotaPropertiesFloat.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesFloat;
-            //if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
-            if (biota.BiotaPropertiesIID != null && biota.BiotaPropertiesIID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesIID;
-            if (biota.BiotaPropertiesInt != null && biota.BiotaPropertiesInt.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt;
-            if (biota.BiotaPropertiesInt64 != null && biota.BiotaPropertiesInt64.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt64;
-            //if (biota.BiotaPropertiesPalette != null && biota.BiotaPropertiesPalette.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPalette;
-            //if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
-            if (biota.BiotaPropertiesSkill != null && biota.BiotaPropertiesSkill.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSkill;
-            //if (biota.BiotaPropertiesSpellBook != null && biota.BiotaPropertiesSpellBook.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSpellBook;
-            if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
-            //if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
-            //if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
+            if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
+            if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
 
             biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
         }

--- a/aclogview/Tools/Scrapers/PlayerWeaponExport.cs
+++ b/aclogview/Tools/Scrapers/PlayerWeaponExport.cs
@@ -11,9 +11,9 @@ using aclogview.ACE_Helpers;
 
 namespace aclogview.Tools.Scrapers
 {
-    class PlayerWeaponExport : Scraper
+    class PlayerExporter : Scraper
     {
-        public override string Description => "Exports players and their weapons";
+        public override string Description => "Exports players and their inventory";
 
         // TODO: player.Character.CharacterPropertiesQuestRegistry
         // TODO: player.Character.HairTexture
@@ -492,7 +492,6 @@ namespace aclogview.Tools.Scrapers
             var biotaWriter = new ACE.Database.SQLFormatters.Shard.BiotaSQLWriter();
             var characterWriter = new ACE.Database.SQLFormatters.Shard.CharacterSQLWriter();
 
-            
             var rwLock = new ReaderWriterLockSlim();
 
             // Export players by login event
@@ -639,13 +638,10 @@ namespace aclogview.Tools.Scrapers
                         if (!woiBeingUsed.AppraiseInfoReceived)
                             partialExportsNoAppraisalInfo.Add($"{woiBeingUsed.Biota.Id:X8}:{woiBeingUsed.Name}");
 
-                        SetBiotaPopulatedCollectionsItem(woiBeingUsed.Biota);
+                        SetBiotaPopulatedCollections(woiBeingUsed.Biota);
 
-                        if ((woiBeingUsed.Biota.WeenieType == 3)||(woiBeingUsed.Biota.WeenieType == 6)||(woiBeingUsed.Biota.WeenieType == 35))
-                        {
-                            using (StreamWriter outputFile = new StreamWriter(fileName, false))
-                                biotaWriter.CreateSQLINSERTStatement(woiBeingUsed.Biota, outputFile);
-                        }
+                        using (StreamWriter outputFile = new StreamWriter(fileName, false))
+                            biotaWriter.CreateSQLINSERTStatement(woiBeingUsed.Biota, outputFile);
                     }
 
                     if (failedExportsUnknownWeenie.Count > 0)
@@ -688,8 +684,8 @@ namespace aclogview.Tools.Scrapers
                     }
 
 
-                    // var resutlsFileName = Path.Combine(loginEventDirectory, "results.txt");
-                    // File.WriteAllText(resutlsFileName, sb.ToString());
+                    var resutlsFileName = Path.Combine(loginEventDirectory, "results.txt");
+                    File.WriteAllText(resutlsFileName, sb.ToString());
                 }
             }
 
@@ -741,7 +737,7 @@ namespace aclogview.Tools.Scrapers
 
                         biota.WeenieType = (int)ACEBiotaCreator.DetermineWeenieType(biota, rwLock);
 
-                        SetBiotaPopulatedCollectionsCharacter(biota);
+                        SetBiotaPopulatedCollections(biota);
 
                         using (StreamWriter outputFile = new StreamWriter(fileName, false))
                             biotaWriter.CreateSQLINSERTStatement(biota, outputFile);
@@ -786,92 +782,30 @@ namespace aclogview.Tools.Scrapers
         {
             PopulatedCollectionFlags populatedCollectionFlags = 0;
 
-            //if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
+            if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
             if (biota.BiotaPropertiesAttribute != null && biota.BiotaPropertiesAttribute.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute;
             if (biota.BiotaPropertiesAttribute2nd != null && biota.BiotaPropertiesAttribute2nd.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute2nd;
-            //if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
-            //if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
-            //if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
+            if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
+            if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
+            if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
             if (biota.BiotaPropertiesBool != null && biota.BiotaPropertiesBool.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBool;
             if (biota.BiotaPropertiesCreateList != null && biota.BiotaPropertiesCreateList.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesCreateList;
             if (biota.BiotaPropertiesDID != null && biota.BiotaPropertiesDID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesDID;
-            //if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
+            if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
             if (biota.BiotaPropertiesEnchantmentRegistry != null && biota.BiotaPropertiesEnchantmentRegistry.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry;
-            //if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
+            if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
             if (biota.BiotaPropertiesFloat != null && biota.BiotaPropertiesFloat.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesFloat;
-            //if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
+            if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
             if (biota.BiotaPropertiesIID != null && biota.BiotaPropertiesIID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesIID;
             if (biota.BiotaPropertiesInt != null && biota.BiotaPropertiesInt.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt;
             if (biota.BiotaPropertiesInt64 != null && biota.BiotaPropertiesInt64.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt64;
             if (biota.BiotaPropertiesPalette != null && biota.BiotaPropertiesPalette.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPalette;
-            //if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
-            if (biota.BiotaPropertiesSkill != null && biota.BiotaPropertiesSkill.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSkill;
-            //if (biota.BiotaPropertiesSpellBook != null && biota.BiotaPropertiesSpellBook.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSpellBook;
-            if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
-            //if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
-            //if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
-
-            biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
-        }
-        private static void SetBiotaPopulatedCollectionsCharacter(Biota biota)
-        {
-            PopulatedCollectionFlags populatedCollectionFlags = 0;
-
-            //if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
-            if (biota.BiotaPropertiesAttribute != null && biota.BiotaPropertiesAttribute.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute;
-            if (biota.BiotaPropertiesAttribute2nd != null && biota.BiotaPropertiesAttribute2nd.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute2nd;
-            //if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
-            //if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
-            //if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
-            if (biota.BiotaPropertiesBool != null && biota.BiotaPropertiesBool.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBool;
-            //if (biota.BiotaPropertiesCreateList != null && biota.BiotaPropertiesCreateList.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesCreateList;
-            if (biota.BiotaPropertiesDID != null && biota.BiotaPropertiesDID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesDID;
-            //if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
-            if (biota.BiotaPropertiesEnchantmentRegistry != null && biota.BiotaPropertiesEnchantmentRegistry.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry;
-            //if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
-            if (biota.BiotaPropertiesFloat != null && biota.BiotaPropertiesFloat.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesFloat;
-            //if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
-            if (biota.BiotaPropertiesIID != null && biota.BiotaPropertiesIID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesIID;
-            if (biota.BiotaPropertiesInt != null && biota.BiotaPropertiesInt.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt;
-            if (biota.BiotaPropertiesInt64 != null && biota.BiotaPropertiesInt64.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt64;
-            if (biota.BiotaPropertiesPalette != null && biota.BiotaPropertiesPalette.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPalette;
-            //if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
+            if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
             if (biota.BiotaPropertiesSkill != null && biota.BiotaPropertiesSkill.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSkill;
             if (biota.BiotaPropertiesSpellBook != null && biota.BiotaPropertiesSpellBook.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSpellBook;
             if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
-            //if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
-            //if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
-
-            biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
-        }
-        private static void SetBiotaPopulatedCollectionsItem(Biota biota)
-        {
-            PopulatedCollectionFlags populatedCollectionFlags = 0;
-
-            //if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
-            if (biota.BiotaPropertiesAttribute != null && biota.BiotaPropertiesAttribute.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute;
-            if (biota.BiotaPropertiesAttribute2nd != null && biota.BiotaPropertiesAttribute2nd.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute2nd;
-            //if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
-            //if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
-            //if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
-            if (biota.BiotaPropertiesBool != null && biota.BiotaPropertiesBool.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBool;
-            //if (biota.BiotaPropertiesCreateList != null && biota.BiotaPropertiesCreateList.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesCreateList;
-            if (biota.BiotaPropertiesDID != null && biota.BiotaPropertiesDID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesDID;
-            //if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
-            if (biota.BiotaPropertiesEnchantmentRegistry != null && biota.BiotaPropertiesEnchantmentRegistry.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry;
-            //if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
-            if (biota.BiotaPropertiesFloat != null && biota.BiotaPropertiesFloat.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesFloat;
-            //if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
-            if (biota.BiotaPropertiesIID != null && biota.BiotaPropertiesIID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesIID;
-            if (biota.BiotaPropertiesInt != null && biota.BiotaPropertiesInt.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt;
-            if (biota.BiotaPropertiesInt64 != null && biota.BiotaPropertiesInt64.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt64;
-            //if (biota.BiotaPropertiesPalette != null && biota.BiotaPropertiesPalette.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPalette;
-            //if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
-            if (biota.BiotaPropertiesSkill != null && biota.BiotaPropertiesSkill.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSkill;
-            //if (biota.BiotaPropertiesSpellBook != null && biota.BiotaPropertiesSpellBook.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSpellBook;
-            if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
-            //if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
-            //if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
+            if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
+            if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
 
             biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
         }

--- a/aclogview/Tools/Scrapers/PlayerWeaponExporter.cs
+++ b/aclogview/Tools/Scrapers/PlayerWeaponExporter.cs
@@ -432,13 +432,9 @@ namespace aclogview.Tools.Scrapers
 
         public override void WriteOutput(string destinationRoot, ref bool writeOutputAborted)
         {
-
+            // From Combat Scraper guid matches
             HashSet<uint> testWCIDs = new HashSet<uint> { 2443969781, 2444221587, 2471506009, 2277838217 };
             HashSet<uint> testCharWCIDs = new HashSet<uint> { 1342259520, 1343430166 };
-
-            //var playerExportsFolder = Path.Combine(destinationRoot, "Player Exports");
-            //if (!Directory.Exists(playerExportsFolder))
-            //    Directory.CreateDirectory(playerExportsFolder);
 
             var playerWeaponExportsFolder = Path.Combine(destinationRoot, "Player and Weapon Weenies");
             if (!Directory.Exists(playerWeaponExportsFolder))
@@ -447,18 +443,8 @@ namespace aclogview.Tools.Scrapers
             // Weapon Details for Combat Report
             StringBuilder weaponDetails = new StringBuilder();
 
-
+            // Not Used
             var notes = new StringBuilder();
-            notes.AppendLine("The following command will import all the sql files into your retail shard. It can take many hours");
-            notes.AppendLine("for /f \"delims=\" %f in ('dir /b /s \"C:\\ACLogView Output\\Player Exports\\Darktide\\*.sql\"') do \"C:\\Program Files\\MySQL\\MySQL Server 8.0\\bin\\mysql\" --user=root --password=password ace_shard_retail_dt < \"%f\"");
-            notes.AppendLine("for /f \"delims=\" %f in ('dir /b /s \"C:\\ACLogView Output\\Player Exports\\Frostfell\\*.sql\"') do \"C:\\Program Files\\MySQL\\MySQL Server 8.0\\bin\\mysql\" --user=root --password=password ace_shard_retail_ff < \"%f\"");
-            notes.AppendLine("for /f \"delims=\" %f in ('dir /b /s \"C:\\ACLogView Output\\Player Exports\\Harvestgain\\*.sql\"') do \"C:\\Program Files\\MySQL\\MySQL Server 8.0\\bin\\mysql\" --user=root --password=password ace_shard_retail_hg < \"%f\"");
-            notes.AppendLine("for /f \"delims=\" %f in ('dir /b /s \"C:\\ACLogView Output\\Player Exports\\Leafcull\\*.sql\"') do \"C:\\Program Files\\MySQL\\MySQL Server 8.0\\bin\\mysql\" --user=root --password=password ace_shard_retail_lc < \"%f\"");
-            notes.AppendLine("for /f \"delims=\" %f in ('dir /b /s \"C:\\ACLogView Output\\Player Exports\\Morningthaw\\*.sql\"') do \"C:\\Program Files\\MySQL\\MySQL Server 8.0\\bin\\mysql\" --user=root --password=password ace_shard_retail_mt < \"%f\"");
-            notes.AppendLine("for /f \"delims=\" %f in ('dir /b /s \"C:\\ACLogView Output\\Player Exports\\Solclaim\\*.sql\"') do \"C:\\Program Files\\MySQL\\MySQL Server 8.0\\bin\\mysql\" --user=root --password=password ace_shard_retail_sc < \"%f\"");
-            notes.AppendLine("for /f \"delims=\" %f in ('dir /b /s \"C:\\ACLogView Output\\Player Exports\\Thistledown\\*.sql\"') do \"C:\\Program Files\\MySQL\\MySQL Server 8.0\\bin\\mysql\" --user=root --password=password ace_shard_retail_td < \"%f\"");
-            notes.AppendLine("for /f \"delims=\" %f in ('dir /b /s \"C:\\ACLogView Output\\Player Exports\\Verdantine\\*.sql\"') do \"C:\\Program Files\\MySQL\\MySQL Server 8.0\\bin\\mysql\" --user=root --password=password ace_shard_retail_vt < \"%f\"");
-            notes.AppendLine("for /f \"delims=\" %f in ('dir /b /s \"C:\\ACLogView Output\\Player Exports\\WintersEbb\\*.sql\"') do \"C:\\Program Files\\MySQL\\MySQL Server 8.0\\bin\\mysql\" --user=root --password=password ace_shard_retail_we < \"%f\"");
 
             // Find guid collisions across servers
             Dictionary<string, HashSet<uint>> guidsByServer = new Dictionary<string, HashSet<uint>>();
@@ -496,14 +482,8 @@ namespace aclogview.Tools.Scrapers
                 }
             }
 
-            //var notesFileName = Path.Combine(playerExportsFolder, "notes.txt");
-            //File.WriteAllText(notesFileName, notes.ToString());
-
-
             var biotaWriter = new ACE.Database.SQLFormatters.Shard.BiotaSQLWriter();
-            var characterWriter = new ACE.Database.SQLFormatters.Shard.CharacterSQLWriter();
-
-            
+            var characterWriter = new ACE.Database.SQLFormatters.Shard.CharacterSQLWriter();           
             var rwLock = new ReaderWriterLockSlim();
 
             // Export players by login event
@@ -524,14 +504,6 @@ namespace aclogview.Tools.Scrapers
                         continue;
 
                     var name = loginEvent.Biota.GetProperty(ACE.Entity.Enum.Properties.PropertyString.Name);
-
-                    //var playerDirectoryRoot = Path.Combine(serverDirectory, name);
-
-                    //var loginEventDirectory = Path.Combine(playerDirectoryRoot, loginEvent.TSec.ToString());
-
-                    //if (!Directory.Exists(loginEventDirectory))
-                    //    Directory.CreateDirectory(loginEventDirectory);
-
                     var sb = new StringBuilder();
 
                     sb.AppendLine("Source: ");
@@ -555,7 +527,6 @@ namespace aclogview.Tools.Scrapers
                     // Biota
                     {
                         var defaultFileName = biotaWriter.GetDefaultFileName(loginEvent.Biota);
-                        //var fileName = Path.Combine(loginEventDirectory, defaultFileName);
                         var fileName = Path.Combine(playerWeaponExportsFolder, defaultFileName);
                         // Hack for changing GUID in file name from Hex to Decimal
                         string idHex = loginEvent.Biota.Id.ToString("X8");
@@ -574,22 +545,6 @@ namespace aclogview.Tools.Scrapers
                                 biotaWriter.CreateSQLINSERTStatement(loginEvent.Biota, outputFile);
                         }
                     }
-
-                    // Character
-                    // Only writing if it finds guid in list, and Changing folder and filename
-                    //{
-
-                    //    loginEvent.Character.Name = name;
-
-                    //    var defaultFileName = loginEvent.Character.Id.ToString() + " " + name + " - Character.sql";
-                    //    var fileName = Path.Combine(playerWeaponExportsFolder, defaultFileName);
-
-                    //    if (testCharWCIDs.Contains(loginEvent.Character.Id))
-                    //    {
-                    //        using (StreamWriter outputFile = new StreamWriter(fileName, false))
-                    //            characterWriter.CreateSQLINSERTStatement(loginEvent.Character, outputFile);
-                    //    }
-                    //}
 
                     // Possessions
                     foreach (var woi in loginEvent.WorldObjects)
@@ -643,10 +598,7 @@ namespace aclogview.Tools.Scrapers
                         processed:
 
                         var defaultFileName = biotaWriter.GetDefaultFileName(woiBeingUsed.Biota);
-
                         defaultFileName = String.Concat(defaultFileName.Split(Path.GetInvalidFileNameChars()));
-
-                        //var fileName = Path.Combine(loginEventDirectory, defaultFileName);
 
                         woiBeingUsed.Biota.WeenieType = (int) ACEBiotaCreator.DetermineWeenieType(woiBeingUsed.Biota, rwLock);
 
@@ -663,25 +615,19 @@ namespace aclogview.Tools.Scrapers
 
 
                         // Only going to write weenies that match GUIDs from HashSet.
-                        // if (woiBeingUsed.Biota.WeenieClassId )
-
                         // Hack for changing GUID in file name from Hex to Decimal
                         string idHex = woiBeingUsed.Biota.Id.ToString("X8");
                         defaultFileName = defaultFileName.Replace(idHex, woiBeingUsed.Biota.Id.ToString());
 
                         var pweFileName = Path.Combine(playerWeaponExportsFolder, defaultFileName);
-
-
-
-
                         if (testWCIDs.Contains(woiBeingUsed.Biota.Id))
                         {
                             using (StreamWriter outputFile = new StreamWriter(pweFileName, false))
                                 biotaWriter.CreateSQLINSERTStatement(woiBeingUsed.Biota, outputFile);
-                            if ((woiBeingUsed.Biota.WeenieType == 3) || (woiBeingUsed.Biota.WeenieType == 6) || (woiBeingUsed.Biota.WeenieType == 35))
-                            {
-                                // weaponDetails.Append($"{woiBeingUsed.Biota.Id},{woiBeingUsed.Name},Mod={woiBeingUsed.Biota.BiotaPropertiesFloat.})
-                            }
+                            //if ((woiBeingUsed.Biota.WeenieType == 3) || (woiBeingUsed.Biota.WeenieType == 6) || (woiBeingUsed.Biota.WeenieType == 35))
+                            //{
+                            //    // weaponDetails.Append($"{woiBeingUsed.Biota.Id},{woiBeingUsed.Name},Mod={woiBeingUsed.Biota.BiotaPropertiesFloat.})
+                            //}
                         }
                         //if ((woiBeingUsed.Biota.WeenieType == 3)||(woiBeingUsed.Biota.WeenieType == 6)||(woiBeingUsed.Biota.WeenieType == 35))
                         //{
@@ -728,13 +674,8 @@ namespace aclogview.Tools.Scrapers
                         if (!loginEvent.WorldObjects.ContainsKey(value))
                             sb.AppendLine($"{value:X8}");
                     }
-
-
-                    // var resutlsFileName = Path.Combine(loginEventDirectory, "results.txt");
-                    // File.WriteAllText(resutlsFileName, sb.ToString());
                 }
             }
-
 
             // Export player biotas that don't have login events
             foreach (var server in biotasByServer)
@@ -763,15 +704,6 @@ namespace aclogview.Tools.Scrapers
                         ACEBiotaCreator.Update(biotaEx.Value.LastAppraisalProfile, biota, rwLock);
 
                     var name = biota.GetProperty(ACE.Entity.Enum.Properties.PropertyString.Name);
-
-                    //var playerDirectoryRoot = Path.Combine(serverDirectory, name);
-
-                    //var playerDirectoryInstance = Path.Combine(playerDirectoryRoot, "0");
-
-                    //if (!Directory.Exists(playerDirectoryInstance))
-                    //    Directory.CreateDirectory(playerDirectoryInstance);
-
-                    // Biota
                     {
                         var defaultFileName = biotaWriter.GetDefaultFileName(biota);
                         //var fileName = Path.Combine(playerDirectoryInstance, defaultFileName);

--- a/aclogview/Tools/Scrapers/PlayerWeaponExporter.cs
+++ b/aclogview/Tools/Scrapers/PlayerWeaponExporter.cs
@@ -11,9 +11,9 @@ using aclogview.ACE_Helpers;
 
 namespace aclogview.Tools.Scrapers
 {
-    class PlayerExporter : Scraper
+    class PlayerWeaponExporter : Scraper
     {
-        public override string Description => "Exports players and their inventory";
+        public override string Description => "Exports players and their weapons";
 
         // TODO: player.Character.CharacterPropertiesQuestRegistry
         // TODO: player.Character.HairTexture
@@ -207,7 +207,8 @@ namespace aclogview.Tools.Scrapers
                                     loginEvent.Biota.SetPosition(ACE.Entity.Enum.Properties.PositionType.Location, position, rwLock, out _);
                                 }
 
-                                // Record inventory items
+                                // Match to Hashset??
+                                // Record inventory items  
                                 if (!loginEvent.WorldObjects.ContainsKey(message.object_id) && loginEvent.IsPossessedItem(message.object_id))
                                 {
                                     var item = new WorldObjectItem(message.object_id, message.wdesc._name.m_buffer);
@@ -226,7 +227,7 @@ namespace aclogview.Tools.Scrapers
                                         biotaServer = new Dictionary<uint, BiotaEx>();
                                         biotasByServer[serverName] = biotaServer;
                                     }
-
+                                    // Add Character guid match list here?
                                     if (!biotaServer.TryGetValue(message.object_id, out var biotaEx))
                                     {
                                         biotaEx = new BiotaEx();
@@ -492,6 +493,7 @@ namespace aclogview.Tools.Scrapers
             var biotaWriter = new ACE.Database.SQLFormatters.Shard.BiotaSQLWriter();
             var characterWriter = new ACE.Database.SQLFormatters.Shard.CharacterSQLWriter();
 
+            
             var rwLock = new ReaderWriterLockSlim();
 
             // Export players by login event
@@ -638,10 +640,17 @@ namespace aclogview.Tools.Scrapers
                         if (!woiBeingUsed.AppraiseInfoReceived)
                             partialExportsNoAppraisalInfo.Add($"{woiBeingUsed.Biota.Id:X8}:{woiBeingUsed.Name}");
 
-                        SetBiotaPopulatedCollections(woiBeingUsed.Biota);
+                        SetBiotaPopulatedCollectionsItem(woiBeingUsed.Biota);
 
-                        using (StreamWriter outputFile = new StreamWriter(fileName, false))
-                            biotaWriter.CreateSQLINSERTStatement(woiBeingUsed.Biota, outputFile);
+
+                        // Only going to write weenies that match GUIDs from list.
+                        // if (woiBeingUsed.Biota.WeenieClassId )
+
+                        if ((woiBeingUsed.Biota.WeenieType == 3)||(woiBeingUsed.Biota.WeenieType == 6)||(woiBeingUsed.Biota.WeenieType == 35))
+                        {
+                            using (StreamWriter outputFile = new StreamWriter(fileName, false))
+                                biotaWriter.CreateSQLINSERTStatement(woiBeingUsed.Biota, outputFile);
+                        }
                     }
 
                     if (failedExportsUnknownWeenie.Count > 0)
@@ -684,8 +693,8 @@ namespace aclogview.Tools.Scrapers
                     }
 
 
-                    var resutlsFileName = Path.Combine(loginEventDirectory, "results.txt");
-                    File.WriteAllText(resutlsFileName, sb.ToString());
+                    // var resutlsFileName = Path.Combine(loginEventDirectory, "results.txt");
+                    // File.WriteAllText(resutlsFileName, sb.ToString());
                 }
             }
 
@@ -737,7 +746,7 @@ namespace aclogview.Tools.Scrapers
 
                         biota.WeenieType = (int)ACEBiotaCreator.DetermineWeenieType(biota, rwLock);
 
-                        SetBiotaPopulatedCollections(biota);
+                        SetBiotaPopulatedCollectionsCharacter(biota);
 
                         using (StreamWriter outputFile = new StreamWriter(fileName, false))
                             biotaWriter.CreateSQLINSERTStatement(biota, outputFile);
@@ -806,6 +815,68 @@ namespace aclogview.Tools.Scrapers
             if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
             if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
             if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
+
+            biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
+        }
+        private static void SetBiotaPopulatedCollectionsCharacter(Biota biota)
+        {
+            PopulatedCollectionFlags populatedCollectionFlags = 0;
+
+            //if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
+            if (biota.BiotaPropertiesAttribute != null && biota.BiotaPropertiesAttribute.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute;
+            if (biota.BiotaPropertiesAttribute2nd != null && biota.BiotaPropertiesAttribute2nd.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute2nd;
+            //if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
+            //if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
+            //if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
+            if (biota.BiotaPropertiesBool != null && biota.BiotaPropertiesBool.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBool;
+            //if (biota.BiotaPropertiesCreateList != null && biota.BiotaPropertiesCreateList.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesCreateList;
+            if (biota.BiotaPropertiesDID != null && biota.BiotaPropertiesDID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesDID;
+            //if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
+            if (biota.BiotaPropertiesEnchantmentRegistry != null && biota.BiotaPropertiesEnchantmentRegistry.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry;
+            //if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
+            if (biota.BiotaPropertiesFloat != null && biota.BiotaPropertiesFloat.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesFloat;
+            //if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
+            if (biota.BiotaPropertiesIID != null && biota.BiotaPropertiesIID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesIID;
+            if (biota.BiotaPropertiesInt != null && biota.BiotaPropertiesInt.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt;
+            if (biota.BiotaPropertiesInt64 != null && biota.BiotaPropertiesInt64.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt64;
+            if (biota.BiotaPropertiesPalette != null && biota.BiotaPropertiesPalette.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPalette;
+            //if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
+            if (biota.BiotaPropertiesSkill != null && biota.BiotaPropertiesSkill.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSkill;
+            if (biota.BiotaPropertiesSpellBook != null && biota.BiotaPropertiesSpellBook.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSpellBook;
+            if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
+            //if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
+            //if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
+
+            biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
+        }
+        private static void SetBiotaPopulatedCollectionsItem(Biota biota)
+        {
+            PopulatedCollectionFlags populatedCollectionFlags = 0;
+
+            //if (biota.BiotaPropertiesAnimPart != null && biota.BiotaPropertiesAnimPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAnimPart;
+            if (biota.BiotaPropertiesAttribute != null && biota.BiotaPropertiesAttribute.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute;
+            if (biota.BiotaPropertiesAttribute2nd != null && biota.BiotaPropertiesAttribute2nd.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesAttribute2nd;
+            //if (biota.BiotaPropertiesBodyPart != null && biota.BiotaPropertiesBodyPart.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBodyPart;
+            //if (biota.BiotaPropertiesBook != null) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBook;
+            //if (biota.BiotaPropertiesBookPageData != null && biota.BiotaPropertiesBookPageData.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBookPageData;
+            if (biota.BiotaPropertiesBool != null && biota.BiotaPropertiesBool.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesBool;
+            //if (biota.BiotaPropertiesCreateList != null && biota.BiotaPropertiesCreateList.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesCreateList;
+            if (biota.BiotaPropertiesDID != null && biota.BiotaPropertiesDID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesDID;
+            //if (biota.BiotaPropertiesEmote != null && biota.BiotaPropertiesEmote.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEmote;
+            if (biota.BiotaPropertiesEnchantmentRegistry != null && biota.BiotaPropertiesEnchantmentRegistry.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEnchantmentRegistry;
+            //if (biota.BiotaPropertiesEventFilter != null && biota.BiotaPropertiesEventFilter.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesEventFilter;
+            if (biota.BiotaPropertiesFloat != null && biota.BiotaPropertiesFloat.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesFloat;
+            //if (biota.BiotaPropertiesGenerator != null && biota.BiotaPropertiesGenerator.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesGenerator;
+            if (biota.BiotaPropertiesIID != null && biota.BiotaPropertiesIID.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesIID;
+            if (biota.BiotaPropertiesInt != null && biota.BiotaPropertiesInt.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt;
+            if (biota.BiotaPropertiesInt64 != null && biota.BiotaPropertiesInt64.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesInt64;
+            //if (biota.BiotaPropertiesPalette != null && biota.BiotaPropertiesPalette.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPalette;
+            //if (biota.BiotaPropertiesPosition != null && biota.BiotaPropertiesPosition.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesPosition;
+            if (biota.BiotaPropertiesSkill != null && biota.BiotaPropertiesSkill.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSkill;
+            //if (biota.BiotaPropertiesSpellBook != null && biota.BiotaPropertiesSpellBook.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesSpellBook;
+            if (biota.BiotaPropertiesString != null && biota.BiotaPropertiesString.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesString;
+            //if (biota.BiotaPropertiesTextureMap != null && biota.BiotaPropertiesTextureMap.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.BiotaPropertiesTextureMap;
+            //if (biota.HousePermission != null && biota.HousePermission.Count > 0) populatedCollectionFlags |= PopulatedCollectionFlags.HousePermission;
 
             biota.PopulatedCollectionFlags = (uint)populatedCollectionFlags;
         }

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -300,7 +300,12 @@
       <Name>Be.Windows.Forms.HexBox</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="CharacterList.txt" />
+    <Content Include="Lists\CharacterList.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -213,7 +213,7 @@
     <Compile Include="Tools\Parsers\SampleParser.cs" />
     <Compile Include="Tools\Parsers\TextSearcher.cs" />
     <Compile Include="Tools\Scrapers\PacketTypesCountScraper.cs" />
-    <Compile Include="Tools\Scrapers\PlayerWeaponExport.cs" />
+    <Compile Include="Tools\Scrapers\PlayerWeaponExporter.cs" />
     <Compile Include="Tools\Scrapers\PlayerExporter.cs" />
     <Compile Include="Tools\Scrapers\Scraper.cs" />
     <Compile Include="Tools\Scrapers\ServerAddressScraper.cs" />

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Enums\StatTypes.cs" />
     <Compile Include="Tools\Parsers\OpcodeFinder.cs" />
     <Compile Include="Tools\Scrapers\AccountExporter.cs" />
+    <Compile Include="Tools\Scrapers\CombatDamageGiven.cs" />
     <Compile Include="Tools\Scrapers\HeatMapGenerator.cs" />
     <Compile Include="Tools\Scrapers\PacketSizeScraperC2S.cs" />
     <Compile Include="Tools\Parsers\SampleParser.cs" />

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -90,6 +90,12 @@
     </Compile>
     <Compile Include="Server.cs" />
     <Compile Include="ServerList.cs" />
+    <Compile Include="Tools\CreatureName.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Tools\CreatureName.Designer.cs">
+      <DependentUpon>CreatureName.cs</DependentUpon>
+    </Compile>
     <Compile Include="Tools\OptionsForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -222,6 +228,9 @@
     <Compile Include="Utility.cs" />
     <EmbeddedResource Include="GotoLine.resx">
       <DependentUpon>GotoLine.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Tools\CreatureName.resx">
+      <DependentUpon>CreatureName.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Tools\OptionsForm.resx">
       <DependentUpon>OptionsForm.cs</DependentUpon>

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -90,6 +90,12 @@
     </Compile>
     <Compile Include="Server.cs" />
     <Compile Include="ServerList.cs" />
+    <Compile Include="Tools\CombatScraper.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Tools\CombatScraper.Designer.cs">
+      <DependentUpon>CombatScraper.cs</DependentUpon>
+    </Compile>
     <Compile Include="Tools\CreatureName.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -228,6 +234,9 @@
     <Compile Include="Utility.cs" />
     <EmbeddedResource Include="GotoLine.resx">
       <DependentUpon>GotoLine.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Tools\CombatScraper.resx">
+      <DependentUpon>CombatScraper.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Tools\CreatureName.resx">
       <DependentUpon>CreatureName.cs</DependentUpon>

--- a/aclogview/aclogview.csproj
+++ b/aclogview/aclogview.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Tools\Parsers\SampleParser.cs" />
     <Compile Include="Tools\Parsers\TextSearcher.cs" />
     <Compile Include="Tools\Scrapers\PacketTypesCountScraper.cs" />
+    <Compile Include="Tools\Scrapers\PlayerWeaponExport.cs" />
     <Compile Include="Tools\Scrapers\PlayerExporter.cs" />
     <Compile Include="Tools\Scrapers\Scraper.cs" />
     <Compile Include="Tools\Scrapers\ServerAddressScraper.cs" />


### PR DESCRIPTION
**Combat Scraper**
This is a new scraper in ACLogView with the intention of helping content creators tune mobs by scraping PCAP's to create a combat damage report.

The Combat Scraper will search PCAPs and generate a report with the combat damage on the creatures you specify.  You can do up to 5 creatures.  Report includes the character name, and weapon guid. Also includes a list of PCAPs in which combat with those creatures you searched for.

If you check "Use Character List" it will use a pre-generated list to find the character names.  
Checking "Export Characters and Weapons to Weenies" will scan the PCAPs that were found to contain the creature names from the combat scrape, and generate weenies for the characters and weapons used in the combat scrape. You can import the weapons and use them for testing, or just get the info needed to duplicate on test server.  The weenies will be created in a folder called "Player and Weapon Weenies" under the specified output folder.

**NOTE:** The character weenie will only be generated if the PCAPs have a logon event.  Also weapons in the combat report may not be found in the PCAPs if there was not a logon event (but they can be).  Just depends on the PCAP.

Its a new menu option under Tools.  Outputs to a csv file.  Here is an example of output:

```
The follwing PCAP files contained combat with your creature search list:
C:\ACE\PCAPs\Tou-Tou\Not Mags\Heero-Yuy13117\pkt_2017-1-30_1485844430_log.pcap
C:\ACE\PCAPs\Tou-Tou\Not Mags\High-Voltage_01-30-2017\pkt_2017-1-31_1485869666_log.pcap

Combat Damage Given to a creature from a player 
CharName,Attack,WeaponGUID,DamageType,Damage,Creature,Critical
Heero-Yuy,Magic,2443969781,Bludge,395,Void Lord,False
Heero-Yuy,Magic,2443969781,Bludge,341,Void Lord,False
Heero-Yuy,Magic,2443969781,Bludge,449,Void Lord,False
Heero-Yuy,Magic,2444221587,Fire,662,Panumbris Shadow,False
Heero-Yuy,Magic,2444221587,Fire,610,Panumbris Shadow,False
Heero-Yuy,Magic,2444221587,Fire,662,Panumbris Shadow,False
```
When opened as a spreadsheet:
![image](https://user-images.githubusercontent.com/30803300/109450356-b20e0880-7a18-11eb-8462-7a853d760e5d.png)

Interface
![image](https://user-images.githubusercontent.com/30803300/109451302-247fe800-7a1b-11eb-95d5-35faa382697c.png)

Output Folder Example 
![image](https://user-images.githubusercontent.com/30803300/109451081-9dcb0b00-7a1a-11eb-866b-c530cc2bb7fd.png)

Player and Weapon Weenies Folder Example
![image](https://user-images.githubusercontent.com/30803300/109451114-b20f0800-7a1a-11eb-9c92-33ea49dc6f0e.png)

